### PR TITLE
Insert exec pr6 complete

### DIFF
--- a/.github/scripts/scan-warnings.sh
+++ b/.github/scripts/scan-warnings.sh
@@ -49,8 +49,8 @@ if [[ "$SNAPSHOT_ACTIVE_COUNT" -ne 44 ]]; then
     ERROR_FOUND=true
 fi
 
-if [[ "$LEAK_COUNT" -ne 416 ]]; then
-    echo "Error: Expected 416 leak warnings, but found $LEAK_COUNT"
+if [[ "$LEAK_COUNT" -ne 30 ]]; then
+    echo "Error: Expected 30 leak warnings, but found $LEAK_COUNT"
     ERROR_FOUND=true
 fi
 

--- a/contrib/babelfishpg_tds/error_mapping.txt
+++ b/contrib/babelfishpg_tds/error_mapping.txt
@@ -187,4 +187,5 @@ XX000 ERRCODE_INTERNAL_ERROR	"The table-valued parameter \"%s\" must be declared
 22008 ERRCODE_DATETIME_VALUE_OUT_OF_RANGE	"Adding a value to a \'%s\' column caused an overflow." SQL_ERROR_517 16
 42P01 ERRCODE_UNDEFINED_TABLE	"FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name."		SQL_ERROR_13600	16
 42P01 ERRCODE_FEATURE_NOT_SUPPORTED	"sub-select and values for json auto are not currently supported."		SQL_ERROR_13600	16
-
+42601 ERRCODE_SYNTAX_ERROR	"nested INSERT ... EXECUTE statements are not allowed"	SQL_ERROR_8164	16
+0A000 ERRCODE_FEATURE_NOT_SUPPORTED	"INSERT EXEC failed because the stored procedure altered the schema of the target table."	SQL_ERROR_556	16

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -190,9 +190,11 @@ SendPendingDone(bool more)
 
 			/*
 			 * If a statement throws an error, the row count should be always
-			 * 0.
-			 */
-			Assert(TdsPendingDoneRowCnt == 0);
+			 * 0. Reset it here in case a previous statement (e.g., INSERT
+			 * inside a procedure during INSERT EXEC) had set a non-zero count
+			 * before the error was thrown.
+			*/
+			TdsPendingDoneRowCnt = 0;
 		}
 
 		TDS_DEBUG(TDS_DEBUG3, "SendPendingDone: putbytes");
@@ -2731,19 +2733,25 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 								 * or if the INSERT itself is an INSERT-EXEC
 								 * and it just returned error.
 								 */
-								row_count_valid = !estate->insert_exec &&
+								row_count_valid =
+									!(pltsql_plugin_handler_ptr->pltsql_insert_exec_active &&
+									  pltsql_plugin_handler_ptr->pltsql_insert_exec_active()) &&
 									!(markErrorFlag &&
 									  ((PLtsql_stmt_execsql *) stmt)->insert_exec);
 							}
 							else if (plansource->commandTag == CMDTAG_UPDATE)
 							{
 								command_type = TDS_CMD_UPDATE;
-								row_count_valid = !estate->insert_exec;
+								row_count_valid =
+									!(pltsql_plugin_handler_ptr->pltsql_insert_exec_active &&
+									  pltsql_plugin_handler_ptr->pltsql_insert_exec_active());
 							}
 							else if (plansource->commandTag == CMDTAG_DELETE)
 							{
 								command_type = TDS_CMD_DELETE;
-								row_count_valid = !estate->insert_exec;
+								row_count_valid =
+									!(pltsql_plugin_handler_ptr->pltsql_insert_exec_active &&
+									  pltsql_plugin_handler_ptr->pltsql_insert_exec_active());
 							}
 
 							/*
@@ -2753,7 +2761,9 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 							else if (plansource->commandTag == CMDTAG_SELECT)
 							{
 								command_type = TDS_CMD_SELECT;
-								row_count_valid = !estate->insert_exec;
+								row_count_valid =
+									!(pltsql_plugin_handler_ptr->pltsql_insert_exec_active &&
+									  pltsql_plugin_handler_ptr->pltsql_insert_exec_active());
 							}
 						}
 					}
@@ -2776,6 +2786,22 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 			{
 				is_proc = true;
 				command_type = TDS_CMD_EXECUTE;
+				/*
+				 * For INSERT EXEC, we need to report the row count.
+				 * The row count is set in flush_insert_exec_temp_table().
+				 */
+				if (stmt->cmd_type == PLTSQL_STMT_EXEC &&
+					((PLtsql_stmt_exec *) stmt)->insert_exec.is_insert_exec)
+				{
+					command_type = TDS_CMD_INSERT;
+					row_count_valid = true;
+				}
+				else if (stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH &&
+					((PLtsql_stmt_exec_batch *) stmt)->insert_exec.is_insert_exec)
+				{
+					command_type = TDS_CMD_INSERT;
+					row_count_valid = true;
+				}
 			}
 			break;
 		default:

--- a/contrib/babelfishpg_tsql/Makefile
+++ b/contrib/babelfishpg_tsql/Makefile
@@ -80,6 +80,7 @@ OBJS += src/fts_parser.o
 OBJS += src/pltsql_partition.o
 OBJS += src/bbf_parallel_query.o
 OBJS += src/temp_table.o
+OBJS += src/pl_insert_exec.o
 
 export ANTLR4_JAVA_BIN=java
 export ANTLR4_RUNTIME_LIB=-lantlr4-runtime

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -802,7 +802,20 @@ pltsql_bbfCustomProcessUtility(ParseState *pstate, PlannedStmt *pstmt, const cha
 		}
 		case T_TransactionStmt:
 		{
-			if (NestedTranCount > 0 || (sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()))
+			TransactionStmt *stmt = (TransactionStmt *) parsetree;
+			/*
+			 * Call PLTsqlProcessTransaction when:
+			 * 1. NestedTranCount > 0 (explicit transaction)
+			 * 2. TSQL dialect and no active transaction block
+			 * 3. INSERT EXEC is active - transaction statements inside the executed
+			 *    procedure must be routed through PLTsqlProcessTransaction where
+			 *    ROLLBACK/COMMIT blocking and NestedTranCount tracking are handled.
+			 */
+			if (NestedTranCount > 0 ||
+				(sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()) ||
+				(pltsql_insert_exec_active() &&
+				 (stmt->kind == TRANS_STMT_ROLLBACK || stmt->kind == TRANS_STMT_ROLLBACK_TO ||
+				  stmt->kind == TRANS_STMT_COMMIT || stmt->kind == TRANS_STMT_BEGIN)))
 			{
 				PLTsqlProcessTransaction(parsetree, params, qc);
 				return true;
@@ -3610,6 +3623,20 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 			/* Call view dependency handling function */
 			handle_bbf_view_binding_on_object_drop(&obj, false);
 		}
+
+		/*
+		 * Detect DROP of the INSERT EXEC target table.
+		 * If the executed procedure drops the target table, we need to fail
+		 * the INSERT EXEC to prevent errors during flush.
+		 */
+		{
+			Oid target_rel_oid = pltsql_insert_exec_get_target_rel_oid();
+
+			if (OidIsValid(target_rel_oid) && objectId == target_rel_oid)
+			{
+				pltsql_insert_exec_set_target_modified();
+			}
+		}
 	}
 	if (access == OAT_DROP && classId == ProcedureRelationId)
 	{
@@ -3643,6 +3670,21 @@ bbf_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId, int s
 
 	if (access == OAT_POST_CREATE)
 		change_object_owner_if_db_owner();
+
+	/*
+	 * Detect schema changes to the INSERT EXEC target table.
+	 * If the executed procedure alters the target table, we need to fail
+	 * the INSERT EXEC to prevent data corruption from schema mismatch.
+	 */
+	if (access == OAT_POST_ALTER && classId == RelationRelationId)
+	{
+		Oid target_rel_oid = pltsql_insert_exec_get_target_rel_oid();
+
+		if (OidIsValid(target_rel_oid) && objectId == target_rel_oid)
+		{
+			pltsql_insert_exec_set_target_modified();
+		}
+	}
 }
 
 static void

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1,5 +1,6 @@
 #include "access/xact.h"
 #include "commands/explain.h"
+#include "utils/snapmgr.h"
 #include "commands/explain_format.h"
 #include "commands/explain_state.h"
 #include "tcop/utility.h"
@@ -46,6 +47,9 @@ static void send_env_change_token_on_txn_abort(void);
 static void process_antlr_parsing_time(PLtsql_execstate *estate);
 static void process_explain(PLtsql_execstate *estate, bool *show_antlr_parsing_time);
 static void process_explain_analyze(PLtsql_execstate *estate, bool *show_antlr_parsing_time);
+
+/* Forward declaration for is_part_of_pltsql_trycatch_block */
+bool is_part_of_pltsql_trycatch_block(PLtsql_execstate *estate);
 
 extern PLtsql_estate_err *pltsql_clone_estate_err(PLtsql_estate_err *err);
 extern void prepare_format_string(StringInfo buf, char *msg_string, int nargs,
@@ -943,7 +947,6 @@ create_error_ctx(PLtsql_execstate *estate, int target_pc)
  * not consider PG_TRY/PG_CATCH in code or C based
  * procedures/functions
  */
-static
 bool
 is_part_of_pltsql_trycatch_block(PLtsql_execstate *estate)
 {
@@ -1181,6 +1184,15 @@ abort_execution(PLtsql_execstate *estate, ErrorData *edata, bool *terminate_batc
 	if (exec_state_call_stack->error_data.rethrow_error)
 		return true;
 
+	/*
+	 * Re-throw INSERT EXEC column mismatch errors BEFORE TRY-CATCH check.
+	 * Unlike catchable errors, column mismatch rolls back ALL rows even
+	 * inside TRY-CATCH. Propagates to exec_stmt_exec's PG_CATCH for rollback.
+	*/
+
+	if (pltsql_insert_exec_active() && pltsql_insert_exec_had_error())
+		return true;
+
 	/* Any error inside try catch block */
 	if (is_part_of_pltsql_trycatch_block(estate))
 		return true;
@@ -1270,6 +1282,15 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 	PG_TRY();
 	{
 		/*
+		 * Variables for internal savepoint decision.
+		 * Declared at block start for C90 compliance.
+		 */
+		bool in_trycatch;
+		bool insert_exec_active;
+		bool need_savepoint_for_insert_exec_trycatch;
+		bool txn_active_or_insert_exec_trycatch;
+
+		/*
 		 * If no transaction is running, start implicit transaction for
 		 * qualified commands when implicit_transactions config option is on
 		 */
@@ -1288,14 +1309,38 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		estate->tsql_trigger_flags = 0;
 
 		/*
-		 * Start an internal savepoint if transaction block is active to
-		 * handle undo of failed command We do not start savepoint for batch
-		 * commands as error handling must be taken care of at statement
-		 * level. For statements inside an RO functions we do not start
-		 * savepoints and let the caller be responsible for handling the
-		 * error.
-		 */
-		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt) && IsTransactionBlockActive() && !is_set_tran_isolation(stmt))
+		 * Start internal savepoint in active txn blocks for undo. Skip for batch
+		 * commands, RO functions, and parallel workers.
+		 *
+		 * Skip during INSERT EXEC (outside TRY-CATCH): subtransaction rollback
+		 * deletes temp table storage. But DO use savepoints inside TRY-CATCH to
+		 * release index refs on caught errors (avoids "cannot DROP" errors).
+ 		*/
+
+
+		in_trycatch = is_part_of_pltsql_trycatch_block(estate);
+		insert_exec_active = pltsql_insert_exec_active();
+
+		/*
+		 * Fallback for cases where exec_state_call_stack is NULL
+		 * (parallel workers, or early-path INSERT EXEC SPI execution).
+		 * Use the TRY-CATCH depth tracked explicitly in INSERT EXEC context.
+		*/
+		if (!in_trycatch && insert_exec_active)
+			in_trycatch = pltsql_insert_exec_in_trycatch();
+
+		/*
+ 		 * Need internal savepoints when: 
+		 * (1) in transaction block and not in INSERT EXEC (or in INSERT EXEC with TRY-CATCH), or 
+		 * (2) INSERT EXEC with TRY-CATCH even without explicit transaction - required to release
+		 * index refs on caught errors, else DROP TABLE fails with "being used".
+		*/
+
+		need_savepoint_for_insert_exec_trycatch = insert_exec_active && in_trycatch;
+		txn_active_or_insert_exec_trycatch = IsTransactionBlockActive() || need_savepoint_for_insert_exec_trycatch;
+
+		if (!ro_func && !pltsql_disable_internal_savepoint && !is_batch_command(stmt) && txn_active_or_insert_exec_trycatch && !is_set_tran_isolation(stmt) &&
+			(!insert_exec_active || in_trycatch) && !IsParallelWorker())
 		{
 			elog(DEBUG5, "TSQL TXN Start internal savepoint");
 			BeginInternalSubTransaction(NULL);
@@ -1326,17 +1371,32 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		estate->impl_txn_type = PLTSQL_IMPL_TRAN_OFF;
 
 		/*
-		 * Handle transaction count mismatch for batch execution if
-		 * implicit_transaction config is off
-		 */
+		 * Handle txn count mismatch when implicit_transaction is off.
+		 * Skip during INSERT EXEC (txn count reconciled on completion),
+		 * on INSERT EXEC error (let original error propagate), or if
+		 * INSERT EXEC started implicit txn (stays open for auto-commit).
+ 		*/
+
+
 		topEntry = simple_econtext_stack;
+
 		if (!pltsql_implicit_transactions &&
 			is_batch_command(stmt) &&
 			!is_part_of_pltsql_trigger(estate) &&
+			!pltsql_insert_exec_active() &&
+			!pltsql_insert_exec_had_error() &&
+			!pltsql_insert_exec_started_implicit_txn() &&
 			before_tran_count != NestedTranCount)
 			ereport(ERROR,
 					(errcode(ERRCODE_T_R_INTEGRITY_CONSTRAINT_VIOLATION),
 					 errmsg("Transaction count after execution indicates a mismatch number of BEGIN and COMMIT statements. Previous count %u current count %u", before_tran_count, NestedTranCount)));
+
+		/*
+		 * Clear implicit txn flag only when NOT inside INSERT EXEC context.
+		*/
+
+		if (pltsql_insert_exec_started_implicit_txn() && !pltsql_insert_exec_active())
+			pltsql_insert_exec_clear_implicit_txn_flag();
 	}
 	PG_CATCH();
 	{
@@ -1370,7 +1430,7 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 			}
 			else if (!IsTransactionBlockActive())
 			{
-				if (is_part_of_pltsql_trycatch_block(estate))
+				if (is_part_of_pltsql_trycatch_block(estate) && !pltsql_insert_exec_active())
 				{
 					HOLD_INTERRUPTS();
 					elog(DEBUG1, "TSQL TXN PG semantics : Rollback current transaction");
@@ -1418,6 +1478,28 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		edata = CopyErrorData();
 		error_mapped = get_tsql_error_code(edata, &last_error);
 		exec_set_error(estate, last_error, edata->sqlerrcode, !error_mapped);
+
+		/*
+		 * Clean up INSERT EXEC context on error (early, before txn handling)
+		 * if TRY-CATCH is at same level or higher. Don't clean up if TRY-CATCH
+		 * is inside the executed procedure. Always clean up for nested INSERT
+		 * EXEC errors (batch-terminating).
+ 		*/
+
+		{
+			bool insert_exec_active = pltsql_insert_exec_active();
+			bool should_cleanup_trycatch = pltsql_insert_exec_should_cleanup_on_trycatch();
+			bool is_nested_insert_exec_error = (edata->sqlerrcode == ERRCODE_SYNTAX_ERROR &&
+											   edata->message != NULL &&
+											   strstr(edata->message, "nested INSERT") != NULL);
+
+			if (insert_exec_active && (should_cleanup_trycatch || is_nested_insert_exec_error))
+			{
+				pltsql_insert_exec_close_target_table();
+				pltsql_clear_insert_exec_context();
+			}
+		}
+
 		if (internal_sp_started &&
 			before_lxid == MyProc->vxid.lxid &&
 			before_subtxn_id == GetCurrentSubTransactionId())
@@ -1433,17 +1515,69 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 		else if (!IsTransactionBlockActive())
 		{
 			/*
-			 * In case of no transaction, rollback the whole transaction to
-			 * match auto commit behavior
+			 * Variable for skip_abort decision.
+			 * Declared at block start for C90 compliance.
 			 */
-			HOLD_INTERRUPTS();
-			elog(DEBUG1, "TSQL TXN TSQL semantics : Rollback current transaction");
-			/* Hold portals to make sure that cursors work */
-			HoldPinnedPortals();
-			AbortCurrentTransaction();
-			StartTransactionCommand();
-			MemoryContextSwitchTo(cur_ctxt);
-			RESUME_INTERRUPTS();
+			bool skip_abort = false;
+
+			/*
+			 * For auto-commit behavior, rollback the transaction when no
+			 * transaction block is active.
+			 *
+			 * Skip during INSERT EXEC if TRY-CATCH will catch the error, since
+			 * AbortCurrentTransaction deletes pending relations including the
+			 * temp table needed for buffering results.
+			*/
+
+			if (pltsql_insert_exec_active())
+			{
+				if (pltsql_insert_exec_in_trycatch())
+				{
+					skip_abort = true;
+				}
+				else
+				{
+					/* No TRY-CATCH: clear INSERT EXEC context; temp table drops on abort. */
+					pltsql_insert_exec_close_target_table();
+					pltsql_clear_insert_exec_context();
+				}
+			}
+
+			if (!skip_abort)
+			{
+				HOLD_INTERRUPTS();
+				elog(DEBUG1, "TSQL TXN TSQL semantics : Rollback current transaction");
+				/* Hold portals to make sure that cursors work */
+				HoldPinnedPortals();
+				AbortCurrentTransaction();
+				StartTransactionCommand();
+				MemoryContextSwitchTo(cur_ctxt);
+				RESUME_INTERRUPTS();
+			}
+			else
+			{
+				/*
+				 * Since we skipped AbortCurrentTransaction() for INSERT EXEC, clean up
+				 * leaked SPI snapshots to avoid "portal snapshots did not account for
+				 * all active snapshots" errors. Also switch to stmt_mcontext_parent
+				 * to avoid deleting the current memory context during cleanup.
+				*/
+
+				HOLD_INTERRUPTS();
+				while (ActiveSnapshotSet())
+					PopActiveSnapshot();
+				if (pltsql_snapshot_portal != NULL)
+					pltsql_snapshot_portal->portalSnapshot = NULL;
+				/* 
+				 * Use stmt_mcontext_parent to avoid deleting the current
+				 * memory context during cleanup. 
+				*/
+				if (estate->stmt_mcontext_parent != NULL)
+					MemoryContextSwitchTo(estate->stmt_mcontext_parent);
+				else
+					MemoryContextSwitchTo(cur_ctxt);
+				RESUME_INTERRUPTS();
+			}
 		}
 		else if (estate->tsql_trigger_flags & TSQL_TRAN_STARTED)
 		{
@@ -1483,6 +1617,9 @@ dispatch_stmt_handle_error(PLtsql_execstate *estate,
 
 		handle_error(estate, stmt, edata, topEntry, terminate_batch, ro_func);
 
+		/* Clear the INSERT EXEC error flag after error handling is complete */
+		pltsql_insert_exec_clear_error_flag();
+
 		rc = PLTSQL_RC_OK;
 	}
 	PG_END_TRY();
@@ -1515,6 +1652,11 @@ exec_stmt_iterative(PLtsql_execstate *estate, ExecCodes *exec_codes, ExecConfig_
 
 	if (!exec_codes)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("Empty execution code")));
+
+	/*
+	 * Clear the INSERT EXEC error flag at the start of each batch.
+	 */
+	pltsql_insert_exec_clear_error_flag();
 
 
 	size = vec_size(exec_codes->codes);
@@ -1602,6 +1744,38 @@ exec_stmt_iterative(PLtsql_execstate *estate, ExecCodes *exec_codes, ExecConfig_
 					estate->cur_error->number = exec_state_call_stack->error_data.error_number;
 					estate->cur_error->severity = exec_state_call_stack->error_data.error_severity;
 					estate->cur_error->state = exec_state_call_stack->error_data.error_state;
+
+					/*
+					 * Clean up INSERT EXEC context if active. Drop temp table here since
+					 * SPI is available after TRY-CATCH.
+					*/
+
+					if (pltsql_insert_exec_should_cleanup_on_trycatch())
+					{
+						Oid temp_oid = pltsql_get_insert_exec_temp_table_oid();
+
+						/* Close target table and release lock first */
+						pltsql_insert_exec_close_target_table();
+
+						/* Clear the INSERT EXEC context */
+						pltsql_clear_insert_exec_context();
+
+						/* Drop the temp table if it exists */
+						if (OidIsValid(temp_oid))
+							drop_insert_exec_temp_table(temp_oid);
+					}
+					else if (pltsql_insert_exec_active())
+					{
+						/*
+						 * TRY-CATCH is inside the executed procedure; INSERT EXEC still in progress.
+						 * Re-throw column mismatch errors (had_error flag) to roll back all rows.
+						 * Other errors (e.g., division by zero) are caught by TRY-CATCH, preserving
+						 * rows inserted before the error.
+						*/
+
+						if (pltsql_insert_exec_had_error())
+							ReThrowError(estate->cur_error->error);
+					}
 
 					/* Goto error handling blocks */
 					*pc = err_handler_pc - 1;	/* same as how goto handles PC */

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -3,17 +3,31 @@
 
 #include "funcapi.h"
 
+#include "access/parallel.h"
 #include "access/table.h"
+#include "parser/parser.h"
+#include "access/tableam.h"
 #include "access/attmap.h"
 #include "access/nbtree.h"
+#include "access/xact.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_attribute.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
 #include "commands/proclang.h"
+#include "commands/trigger.h"
+#include "executor/executor.h"
 #include "executor/tstoreReceiver.h"
+#include "executor/tuptable.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
 #include "nodes/parsenodes.h"
+#include "parser/parse_coerce.h"
 #include "utils/acl.h"
+#include "utils/lsyscache.h"
+#include "utils/plancache.h"
+#include "utils/syscache.h"
 #include "storage/lmgr.h"
 #include "storage/procarray.h"
 #include "pltsql_bulkcopy.h"
@@ -22,6 +36,8 @@
 
 #include "catalog.h"
 #include "dbcmds.h"
+#include "err_handler.h"
+#include "multidb.h"
 #include "rolecmds.h"
 #include "pl_explain.h"
 #include "pltsql.h"
@@ -68,7 +84,6 @@ static int	exec_stmt_fulltextindex(PLtsql_execstate *estate, PLtsql_stmt_fulltex
 static int	exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt);
 static int	exec_stmt_partition_function(PLtsql_execstate *estate, PLtsql_stmt_partition_function *stmt);
 static int	exec_stmt_partition_scheme(PLtsql_execstate *estate, PLtsql_stmt_partition_scheme *stmt);
-static int	exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *expr);
 static int	exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *expr);
 static int	exec_stmt_dbcc(PLtsql_execstate *estate, PLtsql_stmt_dbcc *stmt);
 extern Datum pltsql_inline_handler(PG_FUNCTION_ARGS);
@@ -80,7 +95,6 @@ static bool is_char_identstart(char c);
 static bool is_char_identpart(char c);
 
 void		read_param_def(InlineCodeBlockArgs *args, const char *paramdefstr);
-bool  		called_from_tsql_insert_exec(void);
 void		cache_inline_args(PLtsql_function *func, InlineCodeBlockArgs *args);
 InlineCodeBlockArgs *create_args(int numargs);
 InlineCodeBlockArgs *clone_inline_args(InlineCodeBlockArgs *args);
@@ -120,7 +134,6 @@ extern SPIPlanPtr prepare_stmt_exec(PLtsql_execstate *estate, PLtsql_function *f
 extern int	sp_prepare_count;
 
 BulkCopyStmt *cstmt = NULL;
-bool		called_from_tsql_insert_execute = false;
 
 int			insert_bulk_rows_per_batch = DEFAULT_INSERT_BULK_ROWS_PER_BATCH;
 int			insert_bulk_kilobytes_per_batch = DEFAULT_INSERT_BULK_PACKET_SIZE;
@@ -133,7 +146,7 @@ static bool prev_insert_bulk_keep_nulls = false;
 static bool prev_insert_bulk_check_constraints = false;
 
 /* return a underlying node if n is implicit casting and underlying node is a certain type of node */
-static Node *get_underlying_node_from_implicit_casting(Node *n, NodeTag underlying_nodetype);
+Node *get_underlying_node_from_implicit_casting(Node *n, NodeTag underlying_nodetype);
 
 /* Enclose a user-defined @@var or @var# name in delimiters */
 static char *delimit_tsql_atatuservar(const char *src);
@@ -516,7 +529,7 @@ exec_stmt_query_set(PLtsql_execstate *estate,
 			break;
 		case SPI_ERROR_TRANSACTION:
 			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					(errcode(ERRCODE_SYNTAX_ERROR),
 					 errmsg("unsupported transaction command in PL/tsql")));
 			break;
 
@@ -559,6 +572,8 @@ static int
 exec_stmt_try_catch(PLtsql_execstate *estate, PLtsql_stmt_try_catch *stmt)
 {
 	volatile int rc = -1;
+	int nest_level_before_subtxn;
+	volatile bool insert_exec_was_active = false;
 
 	/*
 	 * Execute the statements in the block's body inside a sub-transaction
@@ -569,6 +584,15 @@ exec_stmt_try_catch(PLtsql_execstate *estate, PLtsql_stmt_try_catch *stmt)
 	ErrorData  *save_cur_error = estate->cur_error->error;
 
 	MemoryContext stmt_mcontext;
+
+	/*
+	 * Check if INSERT EXEC is active at the start of the TRY block.
+	 * If so, we need special handling to preserve INSERT EXEC data
+	 * when a statement-terminating error occurs.
+	 */
+	insert_exec_was_active = pltsql_insert_exec_active();
+
+	nest_level_before_subtxn = GetCurrentTransactionNestLevel();
 
 	estate->err_text = gettext_noop("during statement block entry");
 
@@ -637,19 +661,71 @@ exec_stmt_try_catch(PLtsql_execstate *estate, PLtsql_stmt_try_catch *stmt)
 	}
 	PG_CATCH();
 	{
-/* 		ErrorData  *edata; */
+		ErrorData  *edata;
+		int			last_error;
+		bool		is_stmt_terminating;
 
 		estate->err_text = gettext_noop("during exception cleanup");
 
 		/* Save error info in our stmt_mcontext */
 		MemoryContextSwitchTo(stmt_mcontext);
-/* 		edata = CopyErrorData(); */
+		edata = CopyErrorData();
 		FlushErrorState();
 
-		/* Abort the inner transaction */
-		RollbackAndReleaseCurrentSubTransaction();
+		/*
+		 * Check if this is a statement-terminating error.
+		 * Statement-terminating errors (like division by zero) should NOT
+		 * roll back previous statements' work in the TRY block.
+		*/
+		(void) get_tsql_error_code(edata, &last_error);
+		is_stmt_terminating = is_ignorable_error(edata->sqlerrcode, 0);
+
+		/*
+		 * For statement-terminating errors with INSERT EXEC active, release
+		 * (commit) the subtransaction instead of rolling back to preserve
+		 * work done before the error. CATCH block still runs.
+ 		*/
+
+		if (is_stmt_terminating && insert_exec_was_active &&
+			GetCurrentTransactionNestLevel() == nest_level_before_subtxn + 1)
+		{
+			/*
+			 * Release the subtransaction to commit all work done before the error.
+			 */
+			ReleaseCurrentSubTransaction();
+		}
+		else
+		{
+			/* Abort the inner transaction */
+			RollbackAndReleaseCurrentSubTransaction();
+		}
+
 		MemoryContextSwitchTo(oldcontext);
 		CurrentResourceOwner = oldowner;
+
+		/*
+		 * Clean up INSERT EXEC only if TRY-CATCH is at same level or higher.
+		 * Don't clean up if TRY-CATCH is inside the executed procedure
+		 * (deeper call stack) since INSERT EXEC is still in progress.
+ 		*/
+
+		if (pltsql_insert_exec_active() && pltsql_insert_exec_should_cleanup_on_trycatch())
+		{
+			Oid temp_oid = pltsql_get_insert_exec_temp_table_oid();
+
+			/* Close target table and release lock first */
+			pltsql_insert_exec_close_target_table();
+
+			/*
+			 * If subtransaction was released (not rolled back), drop the temp table.
+			 * When rolled back, the temp table is already gone.
+			 */
+			if (is_stmt_terminating && insert_exec_was_active && OidIsValid(temp_oid))
+				drop_insert_exec_temp_table(temp_oid);
+
+			/* Clear the INSERT EXEC context AFTER dropping temp table */
+			pltsql_clear_insert_exec_context();
+		}
 
 		/*
 		 * Set up the stmt_mcontext stack as though we had restored our
@@ -681,6 +757,9 @@ exec_stmt_try_catch(PLtsql_execstate *estate, PLtsql_stmt_try_catch *stmt)
 		 */
 		estate->eval_tuptable = NULL;
 		exec_eval_cleanup(estate);
+
+		/* Free the error data now that we've extracted what we need */
+		FreeErrorData(edata);
 
 		rc = exec_stmt(estate, stmt->handler);
 
@@ -741,14 +820,24 @@ exec_stmt_push_result(PLtsql_execstate *estate,
 
 	Assert(stmt->query != NULL);
 
-	/* Handle naked SELECT stmt differently for INSERT ... EXECUTE */
-	if (estate->insert_exec)
-		return exec_stmt_insert_execute_select(estate, stmt->query);
-
 	exec_run_select(estate, stmt->query, &portal);
 
-	receiver = CreateDestReceiver(DestRemote);
-	SetRemoteDestReceiverParams(receiver, portal);
+	/*
+	 * When INSERT EXEC is active, redirect results to the temp table
+	 * instead of sending to client. Column count is validated early
+	 * (in exec_stmt_execsql) and again in insertexec_startup().
+	 */
+	if (pltsql_insert_exec_active())
+	{
+		Oid temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
+		receiver = CreateInsertExecDestReceiver(temp_table_oid);
+		receiver->rStartup(receiver, CMD_SELECT, portal->tupDesc);
+	}
+	else
+	{
+		receiver = CreateDestReceiver(DestRemote);
+		SetRemoteDestReceiverParams(receiver, portal);
+	}
 
 	if (PortalRun(portal,
 				  FETCH_ALL,
@@ -794,8 +883,21 @@ exec_run_dml_with_output(PLtsql_execstate *estate, PLtsql_stmt_push_result *stmt
 		elog(ERROR, "could not open implicit cursor for query \"%s\": %s",
 			 expr->query, SPI_result_code_string(SPI_result));
 
-	receiver = CreateDestReceiver(DestRemote);
-	SetRemoteDestReceiverParams(receiver, portal);
+	/*
+	 * INSERT EXEC context check - redirect OUTPUT clause results to temp table
+	 * instead of sending to client.
+	 */
+	if (pltsql_insert_exec_active())
+	{
+		Oid temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
+		receiver = CreateInsertExecDestReceiver(temp_table_oid);
+		receiver->rStartup(receiver, CMD_SELECT, portal->tupDesc);
+	}
+	else
+	{
+		receiver = CreateDestReceiver(DestRemote);
+		SetRemoteDestReceiverParams(receiver, portal);
+	}
 
 	success = PortalRun(portal,
 						FETCH_ALL,
@@ -839,7 +941,11 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 	char 	*save_db_name = get_cur_db_name();
 
 	/* whether procedure was created WITH RECOMPILE */
-	bool created_with_recompile = false;		
+	bool created_with_recompile = false;
+
+	/* INSERT EXEC handling - temp table lifecycle */
+	bool insert_exec_setup_done = false;
+	Oid insert_exec_temp_oid = InvalidOid;
 
 	/*
 	 * We need to disable the explain gucs incase of sp_reset_connection
@@ -864,9 +970,19 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 		int32		rettypmod;	/* used for scalar function */
 		bool		is_scalar_func;
 
-		/* for EXEC as part of inline code under INSERT ... EXECUTE */
-		Tuplestorestate *tss;
-		DestReceiver *dest;
+		/*
+		 * Setup INSERT EXEC: create temp table to capture procedure output.
+		 * After procedure completes, temp table is flushed to target table.
+		 */
+		if (stmt->insert_exec.is_insert_exec && stmt->insert_exec.target != NULL)
+		{
+			insert_exec_setup(estate, stmt->insert_exec.target,
+							stmt->insert_exec.schema, stmt->insert_exec.db_name,
+							stmt->insert_exec.columns,
+							true, &insert_exec_temp_oid);
+
+			insert_exec_setup_done = true;
+		}
 
 		if (IS_TDS_CONN())
 		{
@@ -934,12 +1050,18 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 
 		stmt->is_scalar_func = is_scalar_func;
 
-		/* T-SQL doesn't allow procedure calls in a function */
+		/*
+		 * T-SQL doesn't allow procedure calls in a function, EXCEPT when
+		 * the procedure is being called as part of INSERT EXEC. In that case,
+		 * the procedure's output is captured into a table variable, which is
+		 * allowed in T-SQL functions.
+		 */
 		if (estate->func && estate->func->fn_oid != InvalidOid && estate->func->fn_prokind == PROKIND_FUNCTION && estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER /* check EXEC is running
 																																									 * in the body of
 																																									 * function */
-			&& !is_scalar_func) /* in case of EXEC on scalar function, it is
+			&& !is_scalar_func /* in case of EXEC on scalar function, it is
 								 * allowed in T-SQL. do not throw an error */
+			&& !stmt->insert_exec.is_insert_exec) /* INSERT EXEC into table variable is allowed in functions */
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
@@ -1152,37 +1274,6 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 			stmt->target = (PLtsql_variable *) row;
 		}
 
-		if (estate->insert_exec)
-		{
-			/*
-			 * For EXEC under INSERT ... EXECUTE, get the expected TupleDesc,
-			 * create a DestReceiver and pass both to the CallStmt so that it
-			 * will know to accumulate result rows and send them back here.
-			 */
-
-			Node	   *node;
-			CallStmt   *callstmt;
-
-			/*
-			 * Get the parsed CallStmt
-			 */
-			node = linitial_node(Query,
-								 ((CachedPlanSource *) linitial(plan->plancache_list))->query_list)->utilityStmt;
-			if (node == NULL || !IsA(node, CallStmt))
-				elog(ERROR, "query for CALL statement is not a CallStmt");
-
-			tss = tuplestore_begin_heap(false, false, work_mem);
-			dest = CreateTuplestoreDestReceiver();
-			SetTuplestoreDestReceiverParams(dest, tss, CurrentMemoryContext, false, NULL, NULL);
-			dest->rStartup(dest, -1, estate->rsi->expectedDesc);
-
-			callstmt = (CallStmt *) node;
-			callstmt->relation = InvalidOid;
-			callstmt->attrnos = NULL;
-			callstmt->retdesc = (void *) estate->rsi->expectedDesc;
-			callstmt->dest = (void *) dest;
-		}
-
 		paramLI = setup_param_list(estate, expr);
 
 		before_lxid = MyProc->vxid.lxid;
@@ -1193,7 +1284,84 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 		options.read_only = estate->readonly_func;
 		options.allow_nonatomic = true;
 
-		rc = SPI_execute_plan_extended(expr->plan, &options);
+		/*
+		 * For INSERT EXEC, wrap the procedure execution in a subtransaction.
+		 * This ensures that if an error occurs (e.g., COMMIT without BEGIN TRAN),
+		 * all changes made by the procedure are rolled back.
+		 *
+		 * For Ownership Chaining : We also switch the security context to the
+		 * procedure owner's identity before executing the inner procedure.
+		 */
+		if (insert_exec_setup_done)
+		{
+			MemoryContext oldcontext = CurrentMemoryContext;
+			ResourceOwner oldowner = CurrentResourceOwner;
+			volatile bool subtxn_started = false;
+			volatile int subtxn_rc = 0;
+			Oid ie_save_userid = InvalidOid;
+			int ie_save_sec_context = 0;
+			volatile bool ie_switched_context = false;
+
+			PG_TRY(insert_exec_subtxn);
+			{
+				BeginInternalSubTransaction("insert_exec_proc");
+				subtxn_started = true;
+				MemoryContextSwitchTo(oldcontext);
+
+				/*
+				 * OWNERSHIP CHAINING:
+				 * Switch to the procedure owner's identity before executing the inner procedure.
+				 * This ensures the EXECUTE permission check uses the procedure owner's identity.
+				 */
+				if (estate->func && OidIsValid(estate->func->fn_oid))
+				{
+					GetUserIdAndSecContext(&ie_save_userid, &ie_save_sec_context);
+					SetUserIdAndSecContext(get_func_owner(estate->func->fn_oid),
+										   ie_save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+					ie_switched_context = true;
+				}
+
+				subtxn_rc = SPI_execute_plan_extended(expr->plan, &options);
+
+				/* Restore security context immediately after SPI call */
+				if (ie_switched_context)
+				{
+					SetUserIdAndSecContext(ie_save_userid, ie_save_sec_context);
+					ie_switched_context = false;
+				}
+
+				/* Procedure completed successfully - release (commit) the subtransaction */
+				ReleaseCurrentSubTransaction();
+				MemoryContextSwitchTo(oldcontext);
+				CurrentResourceOwner = oldowner;
+			}
+			PG_CATCH(insert_exec_subtxn);
+			{
+				/* Restore security context on error if it was switched */
+				if (ie_switched_context)
+				{
+					SetUserIdAndSecContext(ie_save_userid, ie_save_sec_context);
+					ie_switched_context = false;
+				}
+
+				/* Roll back the subtransaction - this undoes the INSERT inside the procedure */
+				if (subtxn_started)
+				{
+					RollbackAndReleaseCurrentSubTransaction();
+				}
+				MemoryContextSwitchTo(oldcontext);
+				CurrentResourceOwner = oldowner;
+
+				PG_RE_THROW();
+			}
+			PG_END_TRY(insert_exec_subtxn);
+
+			rc = subtxn_rc;
+		}
+		else
+		{
+			rc = SPI_execute_plan_extended(expr->plan, &options);
+		}
 
 		after_lxid = MyProc->vxid.lxid;
 
@@ -1242,45 +1410,18 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 				exec_assign_value(estate, (PLtsql_datum *) return_code, Int32GetDatum(pltsql_proc_return_code), false, INT4OID, 0);
 			}
 		}
-
-		if (estate->insert_exec)
-		{
-			/*
-			 * For EXEC under INSERT ... EXECUTE, get the rows sent back by
-			 * the CallStmt, and store them into estate->tuple_store so that
-			 * at the end of function execution they will be sent to the right
-			 * place.
-			 */
-			TupleTableSlot *slot = MakeSingleTupleTableSlot(estate->rsi->expectedDesc,
-															&TTSOpsMinimalTuple);
-
-			if (estate->tuple_store == NULL)
-				exec_init_tuple_store(estate);
-
-			for (;;)
-			{
-				if (!tuplestore_gettupleslot(tss, true, false, slot))
-					break;
-				tuplestore_puttupleslot(estate->tuple_store, slot);
-				ExecClearTuple(slot);
-			}
-			ExecDropSingleTupleTableSlot(slot);
-
-			dest->rShutdown(dest);
-			dest->rDestroy(dest);
-		}
 	}
-	PG_FINALLY();
+	PG_CATCH();
 	{
+		/* Cleanup INSERT EXEC state on error */
+		insert_exec_error_cleanup(insert_exec_setup_done);
+
 		if (strcmp(get_current_pltsql_db_name(), save_db_name) != 0)
 			set_cur_user_db_and_path(save_db_name, false, false);
 
 		pfree(save_db_name);
 
-		/*
-		 * If we aren't saving the plan, unset the pointer.  Note that it
-		 * could have been unset already, in case of a recursive call.
-		 */
+		/* Free plan if not saved */
 		if (expr->plan && !expr->plan->saved)
 		{
 			SPIPlanPtr	plan = expr->plan;
@@ -1288,8 +1429,28 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 			expr->plan = NULL;
 			SPI_freeplan(plan);
 		}
+
+		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
+	/* Cleanup that was in PG_FINALLY - runs on success path */
+	if (strcmp(get_current_pltsql_db_name(), save_db_name) != 0)
+		set_cur_user_db_and_path(save_db_name, false, false);
+
+	    pfree(save_db_name);
+
+	/*
+	 * If we aren't saving the plan, unset the pointer.  Note that it
+	 * could have been unset already, in case of a recursive call.
+	 */
+	if (expr->plan && !expr->plan->saved)
+	{
+		SPIPlanPtr	plan = expr->plan;
+
+		expr->plan = NULL;
+		SPI_freeplan(plan);
+	}
 
 	if (rc < 0)
 		elog(ERROR, "SPI_execute_plan_with_paramlist failed executing query \"%s\": %s",
@@ -1314,6 +1475,10 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 
 	exec_eval_cleanup(estate);
 	SPI_freetuptable(SPI_tuptable);
+
+	/* Flush temp table to target table and cleanup after procedure completes */
+	if (insert_exec_setup_done)
+		insert_exec_success_cleanup(estate, insert_exec_temp_oid);
 
 	return PLTSQL_RC_OK;
 }
@@ -1486,8 +1651,13 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	SimpleEcontextStackEntry *topEntry = NULL;
 	volatile int save_nestlevel = 0;
 	volatile int scope_level = 0;
-	char	   *old_db_name = get_cur_db_name();
+	char	   *old_db_name;
 	char	   *cur_db_name = NULL;
+	MemoryContext saved_context;
+
+	/* INSERT EXEC handling - temp table lifecycle */
+	bool insert_exec_setup_done = false;
+	Oid insert_exec_temp_oid = InvalidOid;
 
 	LOCAL_FCINFO(fcinfo, 1);
 
@@ -1497,15 +1667,34 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 	 */
 	query = exec_eval_expr(estate, stmt->expr, &isnull, &restype, &restypmod);
 	if (isnull)
-	{
-		/* No op in case of null */
 		return PLTSQL_RC_OK;
-	}
+
+	/*
+	 * Allocate old_db_name in TopMemoryContext so it survives any memory
+	 * context switches during nested EXECUTE calls.
+	 */
+	saved_context = MemoryContextSwitchTo(TopMemoryContext);
+	old_db_name = get_cur_db_name();
+	MemoryContextSwitchTo(saved_context);
 	save_nestlevel = pltsql_new_guc_nest_level();
 	scope_level = pltsql_new_scope_identity_nest_level();
 
 	PG_TRY();
 	{
+		/*
+		 * Setup INSERT EXEC: create temp table to capture procedure output.
+		 * No implicit transaction for dynamic SQL (different semantics than stored procs).
+		 */
+		if (stmt->insert_exec.is_insert_exec && stmt->insert_exec.target != NULL)
+		{
+			insert_exec_setup(estate, stmt->insert_exec.target,
+							stmt->insert_exec.schema, stmt->insert_exec.db_name,
+							stmt->insert_exec.columns,
+							false, &insert_exec_temp_oid);
+
+			insert_exec_setup_done = true;
+		}
+
 		/* Get the C-String representation */
 		querystr = convert_value_to_string(estate, query, restype);
 
@@ -1527,25 +1716,41 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 		if (fcinfo->isnull)
 			elog(ERROR, "pltsql_inline_handler failed");
 	}
-	PG_FINALLY();
+	PG_CATCH();
 	{
-		/* Restore past settings */
+		/* Cleanup INSERT EXEC state on error */
+		insert_exec_error_cleanup(insert_exec_setup_done);
+
+		/* Restore GUC and scope identity settings */
 		pltsql_revert_guc(save_nestlevel);
 		pltsql_revert_last_scope_identity(scope_level);
 
+		/* Restore database context */
 		cur_db_name = get_cur_db_name();
 		if (strcmp(cur_db_name, old_db_name) != 0)
+		{
 			set_cur_user_db_and_path(old_db_name, false, false);
+		}
+
+		pfree(old_db_name);
+
+		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
+	/* Restore past settings */
+	pltsql_revert_guc(save_nestlevel);
+	pltsql_revert_last_scope_identity(scope_level);
+
+	cur_db_name = get_cur_db_name();
+	if (strcmp(cur_db_name, old_db_name) != 0)
+	{
+		set_cur_user_db_and_path(old_db_name, false, false);
+	}
+
 	after_lxid = MyProc->vxid.lxid;
 
-	/*
-	 * This logic is similar to what we do in exec_stmt_exec_spexecutesql().
-	 * If we are in a different transaction here, we need to build new
-	 * simple-expression infrastructure.
-	 */
+	/* Rebuild simple-expression infrastructure if transaction changed */
 	if (before_lxid != after_lxid ||
 		simple_econtext_stack == NULL ||
 		topEntry != simple_econtext_stack)
@@ -1555,6 +1760,14 @@ exec_stmt_exec_batch(PLtsql_execstate *estate, PLtsql_stmt_exec_batch *stmt)
 		pltsql_create_econtext(estate);
 	}
 	exec_eval_cleanup(estate);
+
+	/* Flush temp table to target and cleanup */
+	if (insert_exec_setup_done)
+		insert_exec_success_cleanup(estate, insert_exec_temp_oid);
+
+	/* Free old_db_name which was allocated in TopMemoryContext */
+	pfree(old_db_name);
+
 	return PLTSQL_RC_OK;
 }
 
@@ -1759,10 +1972,10 @@ evaluate_sp_cursor_param_values(PLtsql_execstate *estate, int paramno, List *par
 		PLtsql_expr *expr = p->expr;
 
 		if (p->name != NULL)
-			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
 							errmsg("named argument is not supported in sp_cursoropen yet")));
 		if (p->mode != FUNC_PARAM_IN)
-			ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
 							errmsg("output argument is not supported in sp_cursoropen yet")));
 
 		(*values)[i] = exec_eval_expr(estate, expr, &isnull, &rettype, &rettypmod);
@@ -2164,10 +2377,14 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 				int			scope_level;
 				InlineCodeBlockArgs *args = NULL;
 				
+				/* INSERT EXEC handling - temp table lifecycle */
+				bool insert_exec_setup_done = false;
+				Oid insert_exec_temp_oid = InvalidOid;
+
 				batch = exec_eval_expr(estate, stmt->query, &isnull1, &restype1, &restypmod1);
 				if (isnull1)
 				{
-					// When called with a NULL argument, sp_executesql should take no action at all
+					/* When called with a NULL argument, sp_executesql should take no action at all */
 					break;
 				}
 
@@ -2209,6 +2426,76 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 
 				PG_TRY();
 				{
+					/*
+					 * INSERT EXEC handling:
+					 * If this is an INSERT EXEC statement (set by parser), create temp table here.
+					 * The procedure output will be redirected to this temp table.
+					 * After procedure completes, we flush temp table to target and cleanup.
+					*/
+					if (stmt->insert_exec.is_insert_exec && stmt->insert_exec.target != NULL)
+					{
+						/*
+						 * Check for nested INSERT EXEC.
+						 * If INSERT EXEC context is already active, this is a nested call.
+						 */
+						if (pltsql_insert_exec_active())
+						{
+							ereport(ERROR,
+									(errcode(ERRCODE_SYNTAX_ERROR),
+									 errmsg("nested INSERT ... EXECUTE statements are not allowed")));
+						}
+
+						/*
+						 * Start implicit transaction for INSERT EXEC if not already in one.
+						 * This matches T-SQL behavior where INSERT EXEC implicitly starts
+						 * a transaction, making @@TRANCOUNT = 1 inside the executed procedure.
+						 *
+						 * The transaction is committed at the end of INSERT EXEC by the
+						 * normal auto-commit mechanism. COMMIT/ROLLBACK are blocked during
+						 * INSERT EXEC by PLTsqlProcessTransaction().
+						 */
+						{
+							bool in_function = (estate->func &&
+												estate->func->fn_oid != InvalidOid &&
+												estate->func->fn_prokind == PROKIND_FUNCTION &&
+												estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER);
+
+							if (!pltsql_disable_batch_auto_commit &&
+								pltsql_support_tsql_transactions() &&
+								!IsTransactionBlockActive() &&
+								!in_function)
+							{
+								elog(DEBUG4, "TSQL TXN Start internal transaction for INSERT EXEC");
+								pltsql_start_txn();
+								pltsql_insert_exec_set_implicit_txn_flag();
+								estate->tsql_trigger_flags |= TSQL_TRAN_STARTED;
+							}
+						}
+
+						/* Set global context info for flush function */
+						pltsql_set_insert_exec_context_info(stmt->insert_exec.target, stmt->insert_exec.columns);
+
+						/*
+						 * Open and hold the target table during INSERT EXEC execution.
+						 * This is critical for detecting schema alterations.
+						 * By holding the target table open, PostgreSQL's CheckTableNotInUse()
+						 * will detect if the procedure tries to ALTER TABLE on the target.
+						 */
+						pltsql_insert_exec_open_target_table(stmt->insert_exec.target,
+															stmt->insert_exec.schema,
+															stmt->insert_exec.db_name);
+
+						/* Create temp table based on target table structure */
+						insert_exec_temp_oid = create_insert_exec_temp_table(stmt->insert_exec.target,
+																		stmt->insert_exec.columns,
+																			stmt->insert_exec.schema);
+
+						/* Set global context so DestReceiver knows where to write */
+						pltsql_set_insert_exec_context(insert_exec_temp_oid);
+
+						insert_exec_setup_done = true;
+					}
+
 					if (strcmp(batchstr, "") != 0)	/* check edge cases for
 													 * sp_executesql */
 					{
@@ -2220,12 +2507,23 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 						exec_assign_value(estate, estate->datums[stmt->return_code_dno], Int32GetDatum(ret), false, INT4OID, 0);
 					}
 				}
-				PG_FINALLY();
+				PG_CATCH();
 				{
+					/* Cleanup INSERT EXEC state on error */
+					insert_exec_error_cleanup(insert_exec_setup_done);
 					pltsql_revert_guc(save_nestlevel);
 					pltsql_revert_last_scope_identity(scope_level);
+					PG_RE_THROW();
 				}
 				PG_END_TRY();
+
+				pltsql_revert_guc(save_nestlevel);
+				pltsql_revert_last_scope_identity(scope_level);
+
+				/* Flush temp table to target and cleanup after sp_executesql completes */
+				if (insert_exec_setup_done)
+					insert_exec_success_cleanup(estate, insert_exec_temp_oid);
+
 				break;
 			}
 		case PLTSQL_EXEC_SP_EXECUTE:
@@ -2951,7 +3249,7 @@ exec_eval_int(PLtsql_execstate *estate,
 	return DatumGetInt32(exprdatum);
 }
 
-static Node *
+Node *
 get_underlying_node_from_implicit_casting(Node *n, NodeTag underlying_nodetype)
 {
 	FuncExpr   *funcexpr = NULL;
@@ -3211,81 +3509,6 @@ exec_stmt_grantdb(PLtsql_execstate *estate, PLtsql_stmt_grantdb *stmt)
 		alter_user_can_connect(stmt->is_grant, grantee_name, dbname);
 		PopActiveSnapshot();
 	}
-	return PLTSQL_RC_OK;
-}
-
-bool called_from_tsql_insert_exec()
-{
-	if (sql_dialect != SQL_DIALECT_TSQL)
-		return false;
-	return called_from_tsql_insert_execute;
-}
-
-/*
- * For naked SELECT stmt in INSERT ... EXECUTE, instead of pushing the result to
- * the client, we accumulate the result in estate->tuple_store (similar to
- * exec_stmt_return_query). Finally the EXECUTE stmt will return the result to
- * the INSERT stmt as rows to insert.
- */
-static int
-exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *query)
-{
-	Portal		portal;
-	uint64		processed = 0;
-	TupleConversionMap *tupmap;
-	MemoryContext oldcontext;
-
-	if (estate->tuple_store == NULL)
-		exec_init_tuple_store(estate);
-
-	Assert(query != NULL);
-	exec_run_select(estate, query, &portal);
-
-	/* Use eval_mcontext for tuple conversion work */
-	oldcontext = MemoryContextSwitchTo(get_eval_mcontext(estate));
-
-	called_from_tsql_insert_execute = true;
-	tupmap = convert_tuples_by_position(portal->tupDesc,
-										estate->tuple_store_desc,
-										gettext_noop("structure of query does not match function result type"));
-	called_from_tsql_insert_execute = false;
-	while (true)
-	{
-		uint64		i;
-
-		SPI_cursor_fetch(portal, true, 50);
-
-		/* SPI will have changed CurrentMemoryContext */
-		MemoryContextSwitchTo(get_eval_mcontext(estate));
-
-		if (SPI_processed == 0)
-			break;
-
-		for (i = 0; i < SPI_processed; i++)
-		{
-			HeapTuple	tuple = SPI_tuptable->vals[i];
-
-			if (tupmap)
-			{
-				called_from_tsql_insert_execute = true;
-				tuple = execute_attr_map_tuple(tuple, tupmap);
-				called_from_tsql_insert_execute = false;
-			}
-			tuplestore_puttuple(estate->tuple_store, tuple);
-			if (tupmap)
-				heap_freetuple(tuple);
-			processed++;
-		}
-
-		SPI_freetuptable(SPI_tuptable);
-	}
-
-	SPI_freetuptable(SPI_tuptable);
-	SPI_cursor_close(portal);
-
-	MemoryContextSwitchTo(oldcontext);
-	exec_eval_cleanup(estate);
-
 	return PLTSQL_RC_OK;
 }
 
@@ -3830,6 +4053,16 @@ execute_plan_and_push_result(PLtsql_execstate *estate, PLtsql_expr *expr, ParamL
 	if (pltsql_explain_only)
 	{
 		receiver = None_Receiver;
+	}
+	else if (pltsql_insert_exec_active())
+	{
+		/*
+		 * INSERT EXEC context is active - redirect results to temp table
+		 * instead of sending to client.
+		 */
+		Oid temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
+		receiver = CreateInsertExecDestReceiver(temp_table_oid);
+		receiver->rStartup(receiver, CMD_SELECT, portal->tupDesc);
 	}
 	else
 	{
@@ -4483,7 +4716,7 @@ exec_stmt_partition_function(PLtsql_execstate *estate, PLtsql_stmt_partition_fun
 	}
 	else if ((*common_utility_plugin_ptr->is_tsql_sqlvariant_datatype) (typ->typoid))
 		ereport(ERROR,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			(errcode(ERRCODE_SYNTAX_ERROR),
 				errmsg("The type '%s' is not yet supported for partition function in Babelfish.", tsql_typename)));
 
 	type_is_collatable = OidIsValid(typ->collation);
@@ -4722,6 +4955,16 @@ set_search_path_for_sp_procs(char *schema)
 {
 	char 		*dbo_schema = get_dbo_schema_name(get_current_pltsql_db_name());
 	char 		*new_search_path;
+
+	/*
+	 * Skip setting search_path if in parallel mode - parallel workers cannot
+	 * set GUC parameters. This is needed for INSERT EXEC with parallel query.
+	 */
+	if (IsParallelWorker() || IsInParallelMode())
+	{
+		pfree(dbo_schema);
+		return;
+	}
 
 	if (schema != NULL && strcmp(schema, "dbo") == 0)
 		new_search_path = psprintf("%s, sys, pg_catalog, %s",

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -274,6 +274,9 @@ static MemoryContext get_stmt_mcontext(PLtsql_execstate *estate);
 static void push_stmt_mcontext(PLtsql_execstate *estate);
 static void pop_stmt_mcontext(PLtsql_execstate *estate);
 
+/* Forward declaration for commit_stmt - used by pl_exec-2.c */
+void		commit_stmt(PLtsql_execstate *estate, bool txnStarted);
+
 static int	exec_stmt_block(PLtsql_execstate *estate,
 							PLtsql_stmt_block *block);
 static int	exec_stmts(PLtsql_execstate *estate,
@@ -322,7 +325,7 @@ static int	exec_stmt_raise(PLtsql_execstate *estate,
 							PLtsql_stmt_raise *stmt);
 static int	exec_stmt_assert(PLtsql_execstate *estate,
 							 PLtsql_stmt_assert *stmt);
-static int	exec_stmt_execsql(PLtsql_execstate *estate,
+int	exec_stmt_execsql(PLtsql_execstate *estate,
 							  PLtsql_stmt_execsql *stmt);
 static void updateColumnUpdatedList(Query *query);
 static int	exec_stmt_dynexecute(PLtsql_execstate *estate,
@@ -440,9 +443,9 @@ static pltsql_CastHashEntry *get_cast_hashentry(PLtsql_execstate *estate,
 												Oid srctype, int32 srctypmod,
 												Oid dsttype, int32 dsttypmod);
 static void exec_init_tuple_store(PLtsql_execstate *estate);
-static void exec_set_found(PLtsql_execstate *estate, bool state);
+void exec_set_found(PLtsql_execstate *estate, bool state);
 static void exec_set_fetch_status(PLtsql_execstate *estate, int status);
-static void exec_set_rowcount(uint64 rowno);
+void exec_set_rowcount(uint64 rowno);
 static void exec_set_error(PLtsql_execstate *estate, int error, int pg_error, bool error_mapping_failed);
 static void pltsql_create_econtext(PLtsql_execstate *estate);
 static void pltsql_commit_not_required_impl_txn(PLtsql_execstate *estate);
@@ -495,7 +498,7 @@ static void
 pltsql_exec_function_cleanup(PLtsql_execstate *estate, PLtsql_function *func, ErrorContextCallback *plerrcontext);
 
 /* Function to set up row Datum */
-static void
+void
 setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
 
 static bool	called_for_tsql_itvf_function = false;
@@ -712,11 +715,8 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 
 		fcinfo->isnull = estate.retisnull;
 
-		if (estate.retisset || estate.insert_exec)
+		if (estate.retisset)
 		{
-			int16 typLen;
-			bool typByVal;
-			MemoryContext oldcontext;
 			ReturnSetInfo *rsi = estate.rsi;
 
 			/* Check caller can handle a set result */
@@ -736,50 +736,6 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 				oldcxt = MemoryContextSwitchTo(estate.tuple_store_cxt);
 				rsi->setDesc = CreateTupleDescCopy(estate.tuple_store_desc);
 				MemoryContextSwitchTo(oldcxt);
-			}
-
-			/* Obtain output parameters for Insert Execute */
-			if (estate.insert_exec)
-			{
-				/* Switch to function's memory context */
-				oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
-
-				if (OidIsValid(estate.rettype))
-				{
-					/* Get return type properties */
-					get_typlenbyval(estate.rettype, &typLen, &typByVal);
-
-					if (typByVal)
-					{
-						execute_call_insert_exec_retval = estate.retval;
-					}
-					else
-					{
-						/* Pass-by-reference, need to copy the data */
-						execute_call_insert_exec_retval = datumCopy(estate.retval,
-																	typByVal,
-																	typLen);
-					}
-				}
-				else
-				{
-					/* For cases where rettype is not properly set, handle gracefully */
-					typLen = -1;    /* Variable length */
-					typByVal = false; /* Pass by reference */
-					
-					/* Only proceed if we have a valid return value */
-					if (estate.retval != (Datum) 0)
-					{
-						execute_call_insert_exec_retval = estate.retval;
-					}
-					else
-					{
-						/* Skip the exec_move_row_from_datum call entirely */
-						execute_call_insert_exec_retval = (Datum) 0;
-					}
-				}
-				MemoryContextSwitchTo(oldcontext);
-
 			}
 
 			estate.retval = (Datum) 0;
@@ -4388,14 +4344,6 @@ pltsql_estate_setup(PLtsql_execstate *estate,
 	estate->plugin_info = NULL;
 
 	estate->nestlevel = -1;
-
-	/*
-	 * When executing a procedure or inline code block, if a ReturnSetInfo is
-	 * passed in, then it's invoked by INSERT ... EXECUTE.
-	 */
-	estate->insert_exec = (func->fn_prokind == PROKIND_PROCEDURE ||
-						   strcmp(func->fn_signature, "inline_code_block") == 0)
-		&& rsi;
 	
 	estate->explain_infos = NIL;
 
@@ -4474,7 +4422,7 @@ execute_txn_command(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt)
  * is recreated when needed for cases like commit/
  * rollbck/rollback to savepoint
  */
-static void
+void
 commit_stmt(PLtsql_execstate *estate, bool txnStarted)
 {
 	SimpleEcontextStackEntry *topEntry = simple_econtext_stack;
@@ -4664,7 +4612,7 @@ is_impl_txn_required_for_execsql(PLtsql_stmt_execsql *stmt)
  * This is a helper to adapt logic from exec_stmt_call. It constructs a PLtsql_row to capture
  * output parameters from a procedure call within an INSERT EXECUTE context.
  */
-static void
+void
 setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt)
 {
     CachedPlanSource *cachedPlanSource;
@@ -4805,7 +4753,7 @@ setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_s
  * needs to use that, fix those callers to push/pop stmt_mcontext.
  * ----------
  */
-static int
+int
 exec_stmt_execsql(PLtsql_execstate *estate,
 				  PLtsql_stmt_execsql *stmt)
 {
@@ -4845,21 +4793,43 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			set_cur_user_db_and_path(stmt->db_name, true, false);
 	}
 
+	/*
+	 * Block ROLLBACK (and ROLLBACK TO SAVEPOINT) during INSERT EXEC.
+	 * ROLLBACK is not allowed within an INSERT-EXEC statement.
+	 * Check this early before any SPI execution.
+	 */
+	if (stmt->txn_data != NULL)
+	{
+		if ((stmt->txn_data->stmt_kind == TRANS_STMT_ROLLBACK ||
+			 stmt->txn_data->stmt_kind == TRANS_STMT_ROLLBACK_TO) &&
+			pltsql_insert_exec_active())
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_TRANSACTION_ROLLBACK),
+					 errmsg("Cannot use the ROLLBACK statement within an INSERT-EXEC statement.")));
+		}
+	}
+
+	/*
+	 * For INSERT EXEC, validate column count BEFORE plan preparation so
+	 * column mismatch errors take priority over runtime errors (e.g., 1/0).
+	 * PostgreSQL's eval_const_expressions() would evaluate expressions first.
+	 *
+	 * Only validate inside TRY blocks; system procedures like sp_columns
+	 * have internal SELECTs with varying column counts outside TRY blocks.
+ 	*/
+
+	if (pltsql_insert_exec_active() && pltsql_insert_exec_in_execution() &&
+		is_part_of_pltsql_trycatch_block(estate))
+	{
+		if (stmt->sqlstmt && stmt->sqlstmt->query)
+		{
+			pltsql_insert_exec_validate_column_count_from_query(stmt->sqlstmt->query);
+		}
+	}
+
 	PG_TRY();
 	{
-		/* Handle naked SELECT stmt differently for INSERT ... EXECUTE */
-		if (stmt->need_to_push_result && estate->insert_exec)
-		{
-			int			ret = exec_stmt_insert_execute_select(estate, expr);
-
-			if (is_cross_db)
-			{
-				if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
-					set_cur_user_db_and_path(cur_dbname, true, false);
-			}
-			return ret;
-		}
-
 		if (expr->plan && expr->plan->oneshot)
 		{
 			SPI_freeplan(expr->plan);
@@ -4891,18 +4861,12 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		/* Check for nested INSERT EXECUTE statements */
 		if (stmt->insert_exec)
 		{
-			/* Walk existing stack for any parent insert exec */
-			PLExecStateCallStack *cur = exec_state_call_stack;
-			while (cur != NULL)
+			/* Nested INSERT EXEC is not allowed */
+			if (pltsql_insert_exec_active())
 			{
-				/* Found parent insert exec - this is a nested INSERT EXECUTE */
-				if (cur->estate->insert_exec)
-				{
-					ereport(ERROR,
-						(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-						errmsg("nested INSERT ... EXECUTE statements are not allowed")));
-				}
-				cur = cur->next;
+				ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+					errmsg("nested INSERT ... EXECUTE statements are not allowed")));
 			}
 		}
 
@@ -5241,12 +5205,17 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		 * Always commit to match auto commit behavior for each statement
 		 * inside batch or procedure, but not user-defined function or
 		 * procedure invoked by INSERT ... EXECUTE.
+		 *
+		 * Also skip commit during INSERT EXEC or its flush phase to avoid
+		 * orphaning SPI portal snapshots.
 		 */
 		/* TODO To let procedure call from PSQL work with old semantics */
 		if ((!pltsql_disable_batch_auto_commit || (stmt->txn_data != NULL)) &&
 			support_tsql_trans &&
 			(enable_txn_in_triggers || estate->trigdata == NULL) &&
-			!ro_func && !estate->insert_exec)
+			!ro_func &&
+			!pltsql_insert_exec_active() &&
+			!pltsql_insert_exec_flush_in_progress())
 		{
 			commit_stmt(estate, (estate->tsql_trigger_flags & TSQL_TRAN_STARTED));
 
@@ -6449,6 +6418,15 @@ exec_stmt_commit(PLtsql_execstate *estate, PLtsql_stmt_commit *stmt)
 static int
 exec_stmt_rollback(PLtsql_execstate *estate, PLtsql_stmt_rollback *stmt)
 {
+	/*
+	 * Block ROLLBACK during INSERT EXEC.
+	 * ROLLBACK is not allowed within an INSERT-EXEC statement.
+	 */
+	if (pltsql_insert_exec_active())
+		ereport(ERROR,
+				(errcode(ERRCODE_TRANSACTION_ROLLBACK),
+				 errmsg("Cannot use the ROLLBACK statement within an INSERT-EXEC statement.")));
+
 	SPI_rollback();
 	SPI_start_transaction();
 
@@ -9670,7 +9648,7 @@ contains_target_param(Node *node, int *target_dno)
  * exec_set_found			Set the global found variable to true/false
  * ----------
  */
-static void
+void
 exec_set_found(PLtsql_execstate *estate, bool state)
 {
 	PLtsql_var *var;
@@ -9697,7 +9675,7 @@ exec_set_fetch_status(PLtsql_execstate *estate, int status)
 	fetch_status_var = status;
 }
 
-static void
+void
 exec_set_rowcount(uint64 rowno)
 {
 	rowcount_var = rowno;
@@ -9887,6 +9865,17 @@ pltsql_estate_cleanup(void)
 									top_es_entry->estate->stmt_mcontext_parent);
 	pfree(exec_state_call_stack);
 	exec_state_call_stack = top_es_entry;
+
+	/*
+	 * Clear stale INSERT EXEC context when the call stack becomes empty.
+	 * This is a safety net to prevent context from leaking between batches.
+	 * Primary cleanup happens in exec_stmt_exec error handlers, but this
+	 * ensures cleanup even if those paths are not taken.
+	 */
+	if (exec_state_call_stack == NULL && pltsql_insert_exec_active())
+	{
+		pltsql_insert_exec_reset_all();
+	}
 }
 
 /*
@@ -9930,6 +9919,14 @@ pltsql_xact_cb(XactEvent event, void *arg)
 	if (event == XACT_EVENT_COMMIT || event == XACT_EVENT_ABORT)
 	{
 		ResetTopTransactionName();
+
+		/*
+		 * Clean up INSERT EXEC context on transaction end. This is a safety
+		 * net for timeouts, interrupts, and other cases where normal cleanup
+		 * paths are bypassed. On commit, any remaining context is stale.
+		 */
+		if (pltsql_insert_exec_active())
+			pltsql_insert_exec_reset_all();
 	}
 
 	/*

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6114,6 +6114,7 @@ _PG_init(void)
 		(*pltsql_protocol_plugin_ptr)->sql_bytea_from_geography = common_utility_plugin_ptr->bytea_from_geography;
 		(*pltsql_protocol_plugin_ptr)->sql_geometry_from_bytea = common_utility_plugin_ptr->geometry_from_bytea;
 		(*pltsql_protocol_plugin_ptr)->sql_geography_from_bytea = common_utility_plugin_ptr->geography_from_bytea;
+		(*pltsql_protocol_plugin_ptr)->pltsql_insert_exec_active = &pltsql_insert_exec_active;
 	}
 
 	get_language_procs("pltsql", &lang_handler_oid, &lang_validator_oid);
@@ -6289,6 +6290,13 @@ terminate_batch(bool send_error, bool compile_error, int SPI_depth)
 
 		pltsql_non_tsql_proc_entry_count = 0;
 		Assert(pltsql_sys_func_entry_count == 0);
+
+		/*
+		 * Clear stale INSERT EXEC context at the end of each top-level batch.
+		 * This is a safety net to prevent context from leaking between batches.
+		 */
+		if (pltsql_insert_exec_active())
+			pltsql_insert_exec_reset_all();
 
 		if (pltsql_snapshot_portal != NULL)
 		{
@@ -6533,7 +6541,7 @@ pltsql_call_handler(PG_FUNCTION_ARGS)
 		if (get_cur_db_id() != saved_dbid)
 			set_cur_user_db_and_path(get_db_name((saved_dbid)), false, CALLED_AS_TRIGGER(fcinfo));
 		if (saved_search_path != NULL && strcmp(saved_search_path, namespace_search_path) != 0
-			&& !IsAbortedTransactionBlockState())
+			&& !IsAbortedTransactionBlockState() && !IsInParallelMode())
 		{
 			pltsql_check_search_path = false;
 			SetConfigOption("search_path", saved_search_path,

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -1,0 +1,1554 @@
+/*-------------------------------------------------------------------------
+ *
+ * pl_insert_exec.c
+ *	  INSERT EXECUTE implementation for Babelfish PL/tsql
+ *
+ * This file contains all logic for the INSERT INTO <target> EXEC <proc>
+ * statement redesign. It implements:
+ *   - InsertExecContext: global state tracking for an active INSERT EXEC
+ *   - DestReceiver (DR_insertexec): captures procedure output into a
+ *     session-local temp table
+ *   - Temp table lifecycle: creation, schema inference, flush, and drop
+ *   - Context management accessors used across pl_exec.c, hooks.c, and
+ *     the TDS layer
+ *
+ *-------------------------------------------------------------------------
+ */
+
+/* Include pltsql.h first to define types used by pltsql-2.h */
+#include "pltsql.h"
+#include "pltsql-2.h"
+
+#include "funcapi.h"
+
+#include "access/parallel.h"
+#include "access/table.h"
+#include "access/heapam.h"
+#include "parser/parser.h"
+#include "access/tableam.h"
+#include "access/attmap.h"
+#include "access/tupconvert.h"
+#include "access/xact.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_attribute.h"
+#include "catalog/pg_namespace.h"
+#include "catalog/pg_proc.h"
+#include "commands/defrem.h"
+#include "executor/executor.h"
+#include "executor/spi_priv.h"
+#include "executor/tstoreReceiver.h"
+#include "executor/tuptable.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "nodes/parsenodes.h"
+#include "optimizer/optimizer.h"
+#include "parser/parse_coerce.h"
+#include "tcop/dest.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
+#include "storage/lmgr.h"
+
+#include "catalog.h"
+#include "multidb.h"
+#include "pltsql_permissions.h"
+#include "session.h"
+#include "parser/scansup.h"
+#include "parser/parse_oper.h"
+#include "utils/builtins.h"
+#include "utils/varlena.h"
+
+extern void exec_set_rowcount(uint64 rowno);
+extern void exec_set_found(PLtsql_execstate *estate, bool state);
+
+/* Forward declaration for called_from_tsql_insert_exec - used by hooks.c */
+bool		called_from_tsql_insert_exec(void);
+
+/*
+ * Flag to indicate we're inside INSERT EXEC tuple conversion.
+ * This is used by the hook in attmap.c to skip type checking and
+ * by tupconvert.c to perform type coercion via exec_tsql_cast_value_hook.
+ */
+bool		called_from_tsql_insert_execute = false;
+
+/*
+ * Hook function for attmap.c/tupconvert.c to check if we're in INSERT EXEC.
+ * When this returns true:
+ *   - build_attrmap_by_position() skips the type mismatch error
+ *   - execute_attr_map_tuple() calls exec_tsql_cast_value_hook for type coercion
+ */
+bool
+called_from_tsql_insert_exec(void)
+{
+	if (sql_dialect != SQL_DIALECT_TSQL)
+		return false;
+	return called_from_tsql_insert_execute;
+}
+
+/*
+ * Get a comma-separated list of non-IDENTITY, non-computed column names
+ * for a table by opening the relation and iterating over its tuple descriptor.
+ */
+static char *
+get_insertable_column_list(const char *table_name, const char *physical_schema)
+{
+	StringInfoData col_list;
+	Oid			relid;
+	Relation	rel;
+	TupleDesc	tupdesc;
+	int			i;
+	bool		first_col = true;
+	char	   *lower_table_name;
+
+	initStringInfo(&col_list);
+
+	lower_table_name = downcase_identifier(table_name, strlen(table_name), false, false);
+
+	/* Resolve the relation OID using RangeVar - works for both regular and temp tables */
+	{
+		RangeVar *rv = makeRangeVar(physical_schema ? pstrdup(physical_schema) : NULL,
+									pstrdup(lower_table_name), -1);
+		relid = RangeVarGetRelid(rv, AccessShareLock, true);
+	}
+
+	pfree(lower_table_name);
+
+	if (!OidIsValid(relid))
+		elog(ERROR, "could not find relation for INSERT EXEC target table: %s",
+			table_name);
+
+	/* Open the relation */
+	rel = table_open(relid, AccessShareLock);
+	tupdesc = RelationGetDescr(rel);
+
+	/* Iterate over columns and build the list */
+	for (i = 0; i < tupdesc->natts; i++)
+	{
+		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
+
+		/* Skip dropped columns */
+		if (attr->attisdropped)
+			continue;
+
+		/* Skip identity columns */
+		if (attr->attidentity != '\0')
+			continue;
+
+		/* Skip generated/computed columns */
+		if (attr->attgenerated != '\0')
+			continue;
+
+		/* Add column name to the list */
+		if (!first_col)
+			appendStringInfoString(&col_list, ", ");
+		appendStringInfoString(&col_list, quote_identifier(NameStr(attr->attname)));
+		first_col = false;
+	}
+
+	table_close(rel, AccessShareLock);
+
+	/* Error if no insertable columns found */
+	if (first_col)
+	{
+		pfree(col_list.data);
+		elog(ERROR, "no insertable columns found for INSERT EXEC target table: %s",
+			table_name);
+	}
+
+	return col_list.data;
+}
+
+/*
+ * DestReceiver struct for INSERT EXEC - captures procedure output into a temp table.
+ */
+typedef struct
+{
+	DestReceiver pub;			/* public fields */
+	Oid			temp_table_oid;	/* OID of temp table to insert into */
+	TupleDesc	typeinfo;		/* tuple descriptor from startup */
+	uint64		rows_inserted;	/* count of rows inserted */
+	/* Projection infrastructure - always used */
+	ExprContext *econtext;		/* expression context for projection */
+	ProjectionInfo *proj_info;	/* projection info for coercion */
+	TupleTableSlot *proj_slot;	/* result slot for projection */
+	CommandId	cid;			/* command ID obtained once in startup, shared across all tuples */
+} DR_insertexec;
+
+/* Forward declarations for DestReceiver callbacks */
+static void insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo);
+static bool insertexec_receive(TupleTableSlot *slot, DestReceiver *self);
+static void insertexec_shutdown(DestReceiver *self);
+static void insertexec_destroy(DestReceiver *self);
+
+/*
+ * Global context for INSERT EXEC - bundled into a single struct for cleaner code.
+ * This context is needed for nested procedure calls during INSERT EXEC.
+ */
+typedef struct InsertExecContext
+{
+	Oid			temp_table_oid;			/* OID of temp table for buffering */
+	char	   *temp_table_name;		/* Name of temp table for buffering (dynamically chosen) */
+	char	   *target_table;			/* Target table name */
+	char	   *column_list;			/* Column list for INSERT */
+	bool		flush_in_progress;		/* True during flush phase to block commit_stmt */
+	PLExecStateCallStack *call_stack_entry;	/* Call stack entry when INSERT EXEC started */
+	bool		had_error;				/* True if INSERT EXEC had an error */
+	Oid			target_rel_oid;			/* OID of target table - lock held to detect schema changes */
+	bool		is_target_relation_modified;	/* Set by ObjectPostAlterHook when target is altered */
+	bool		started_implicit_txn;	/* True if INSERT EXEC started an implicit transaction */
+} InsertExecContext;
+
+/* Global INSERT EXEC context - reset via memset in pltsql_insert_exec_reset_all() */
+static InsertExecContext insert_exec_ctx;
+
+/*
+ * Set the global INSERT EXEC context with target table info.
+ * Called from ANTLR parser when INSERT EXEC is detected.
+ * This is called BEFORE temp table creation - just stores the target info.
+ *
+ * IMPORTANT: We allocate in TopMemoryContext so the strings survive
+ * error handling (PG_CATCH blocks). The current memory context may be
+ * reset during error processing, which would corrupt these pointers.
+ */
+void
+pltsql_set_insert_exec_context_info(const char *target_table, const char *column_list)
+{
+	MemoryContext oldcontext;
+
+	/* Clear any previous context */
+	if (insert_exec_ctx.target_table)
+	{
+		pfree(insert_exec_ctx.target_table);
+		insert_exec_ctx.target_table = NULL;
+	}
+	if (insert_exec_ctx.column_list)
+	{
+		pfree(insert_exec_ctx.column_list);
+		insert_exec_ctx.column_list = NULL;
+	}
+
+	/* Allocate in TopMemoryContext so strings survive error handling */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	insert_exec_ctx.target_table = target_table ? pstrdup(target_table) : NULL;
+	insert_exec_ctx.column_list = column_list ? pstrdup(column_list) : NULL;
+	MemoryContextSwitchTo(oldcontext);
+
+	/*
+	 * Snapshot the call stack entry when INSERT EXEC starts.
+	 * This pointer comparison replaces depth counting for determining
+	 * if an error occurred at the INSERT EXEC level or inside the
+	 * executed procedure.
+	 */
+	insert_exec_ctx.call_stack_entry = exec_state_call_stack;
+}
+
+/*
+ * Set the global INSERT EXEC context with temp table OID.
+ * Called when temp table is created in exec_stmt_exec.
+ */
+void
+pltsql_set_insert_exec_context(Oid temp_table_oid)
+{
+	insert_exec_ctx.temp_table_oid = temp_table_oid;
+}
+
+/*
+ * Clear the global INSERT EXEC context.
+ * Called when exiting INSERT EXEC context normally.
+ * Note: Does not clear had_error or started_implicit_txn flags, which are
+ * needed for post-cleanup transaction count mismatch checks.
+ */
+void
+pltsql_clear_insert_exec_context(void)
+{
+	insert_exec_ctx.temp_table_oid = InvalidOid;
+	insert_exec_ctx.call_stack_entry = NULL;
+	insert_exec_ctx.flush_in_progress = false;
+	if (insert_exec_ctx.target_table)
+	{
+		pfree(insert_exec_ctx.target_table);
+		insert_exec_ctx.target_table = NULL;
+	}
+	if (insert_exec_ctx.column_list)
+	{
+		pfree(insert_exec_ctx.column_list);
+		insert_exec_ctx.column_list = NULL;
+	}
+	if (insert_exec_ctx.temp_table_name)
+	{
+		pfree(insert_exec_ctx.temp_table_name);
+		insert_exec_ctx.temp_table_name = NULL;
+	}
+}
+
+/*
+ * Full reset of INSERT EXEC context for safety net cleanup paths.
+ * Called when stale context is detected (e.g., empty call stack, batch end).
+ * Unlike pltsql_clear_insert_exec_context(), this also clears the error and
+ * implicit transaction flags, and releases target table resources.
+ */
+void
+pltsql_insert_exec_reset_all(void)
+{
+	/* Release target table lock */
+	pltsql_insert_exec_close_target_table();
+
+	/* Free any allocated strings before memset */
+	if (insert_exec_ctx.target_table)
+		pfree(insert_exec_ctx.target_table);
+	if (insert_exec_ctx.column_list)
+		pfree(insert_exec_ctx.column_list);
+	if (insert_exec_ctx.temp_table_name)
+		pfree(insert_exec_ctx.temp_table_name);
+
+	/* Reset all fields to zero/NULL */
+	memset(&insert_exec_ctx, 0, sizeof(InsertExecContext));
+}
+
+/*
+ * Set the INSERT EXEC error flag.
+ * Called when an error occurs during INSERT EXEC.
+ * This flag is used to skip the transaction count mismatch check.
+ */
+void
+pltsql_insert_exec_set_error_flag(void)
+{
+	insert_exec_ctx.had_error = true;
+}
+
+/*
+ * Check if INSERT EXEC had an error.
+ * Used to skip the transaction count mismatch check.
+ */
+bool
+pltsql_insert_exec_had_error(void)
+{
+	return insert_exec_ctx.had_error;
+}
+
+/*
+ * Clear the INSERT EXEC error flag.
+ * Called after the error has been handled.
+ */
+void
+pltsql_insert_exec_clear_error_flag(void)
+{
+	insert_exec_ctx.had_error = false;
+}
+
+/*
+ * Set the flag indicating INSERT EXEC started an implicit transaction.
+ * This flag persists even after the INSERT EXEC context is cleared,
+ * so it can be used to skip the transaction count mismatch check.
+ */
+void
+pltsql_insert_exec_set_implicit_txn_flag(void)
+{
+	elog(DEBUG4, "TSQL TXN Setting implicit txn flag for INSERT EXEC (was %d, setting to true)",
+		 insert_exec_ctx.started_implicit_txn);
+	insert_exec_ctx.started_implicit_txn = true;
+	elog(DEBUG4, "TSQL TXN After setting implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
+}
+
+/*
+ * Check if INSERT EXEC started an implicit transaction.
+ * Used to skip the transaction count mismatch check.
+ */
+bool
+pltsql_insert_exec_started_implicit_txn(void)
+{
+	elog(DEBUG4, "TSQL TXN Checking implicit txn flag: %d", insert_exec_ctx.started_implicit_txn);
+	return insert_exec_ctx.started_implicit_txn;
+}
+
+/*
+ * Clear the flag indicating INSERT EXEC started an implicit transaction.
+ * Called after the transaction count mismatch check has been skipped.
+ */
+void
+pltsql_insert_exec_clear_implicit_txn_flag(void)
+{
+	elog(DEBUG4, "TSQL TXN Clearing implicit txn flag (was %d)", insert_exec_ctx.started_implicit_txn);
+	insert_exec_ctx.started_implicit_txn = false;
+}
+
+/*
+ * Capture target table OID and lock for change detection.
+ * Regular tables get RowExclusiveLock to block concurrent DDL;
+ * temp tables only get OID captured (session-local).
+ *
+ * Schema changes are detected via is_target_relation_modified flag,
+ * which is set by the ObjectPostAlterHook when the target table is altered.
+ */
+void
+pltsql_insert_exec_open_target_table(const char *target_table,
+                                     const char *schema_name_in,
+                                     const char *db_name_in)
+{
+	RangeVar   *rv;
+	Oid			relid;
+	char	   *schema_name = NULL;
+	char	   *table_name = NULL;
+	char	   *physical_schema = NULL;
+	MemoryContext oldcontext;
+	bool		is_temp_table;
+
+	if (target_table == NULL)
+		return;
+
+	is_temp_table = (target_table[0] == '#' || target_table[0] == '@');
+
+	if (is_temp_table)
+	{
+		/*
+		 * Temp table or table variable - resolve using RangeVarGetRelid.
+		 * We don't need to lock because they're session-local.
+		 */
+		rv = makeRangeVar(NULL, pstrdup(target_table), -1);
+		relid = RangeVarGetRelid(rv, NoLock, true);
+
+		if (!OidIsValid(relid))
+			return;
+
+		/* Store the OID for schema verification (no lock for temp tables) */
+		insert_exec_ctx.target_rel_oid = relid;
+	}
+	else
+	{
+		table_name = pstrdup(target_table);
+		if (schema_name_in != NULL)
+			schema_name = pstrdup(schema_name_in);
+		else
+			schema_name = pstrdup("dbo");  /* default schema */
+		physical_schema = get_physical_schema_name(get_cur_db_name(), schema_name);
+
+		/* Create RangeVar and get the relation OID */
+		rv = makeRangeVar(physical_schema, table_name, -1);
+		relid = RangeVarGetRelid(rv, NoLock, true);
+
+		if (schema_name)
+			pfree(schema_name);
+		if (table_name)
+			pfree(table_name);
+		if (physical_schema)
+			pfree(physical_schema);
+
+		if (!OidIsValid(relid))
+		{
+			/* Table doesn't exist - will be caught later during flush */
+			return;
+		}
+
+		/*
+		 * Acquire RowExclusiveLock on the target table.
+		 * This lock will be held until the end of the transaction.
+		 * It blocks concurrent sessions from modifying the table.
+		 * Note: Same-session DROP/ALTER is still allowed by PostgreSQL,
+		 * but we detect it via is_target_relation_modified flag set by
+		 * ObjectPostAlterHook.
+		 */
+		oldcontext = CurrentMemoryContext;
+		PG_TRY();
+		{
+			LockRelationOid(relid, RowExclusiveLock);
+		}
+		PG_CATCH();
+		{
+			MemoryContextSwitchTo(oldcontext);
+			FlushErrorState();
+			return;
+		}
+		PG_END_TRY();
+
+		insert_exec_ctx.target_rel_oid = relid;
+	}
+
+	/* Initialize the modification flag to false */
+	insert_exec_ctx.is_target_relation_modified = false;
+}
+
+/*
+ * Close the target table that was held open during INSERT EXEC.
+ * Called after the flush completes or on error cleanup.
+ *
+ * For regular tables: Release the RowExclusiveLock we acquired.
+ * For temp tables: Just clear the OID (no lock was acquired).
+ *
+ * Note: We only release the lock if we're not in an aborted transaction state.
+ * If the transaction was aborted, the lock has already been released.
+ */
+void
+pltsql_insert_exec_close_target_table(void)
+{
+	if (OidIsValid(insert_exec_ctx.target_rel_oid))
+	{
+		const char *target = insert_exec_ctx.target_table;
+		bool is_temp_table = (target != NULL && (target[0] == '#' || target[0] == '@'));
+
+		/*
+		 * Only release the lock for regular tables (not temp tables).
+		 * Temp tables don't have locks to release.
+		 */
+		if (!is_temp_table && !IsAbortedTransactionBlockState())
+		{
+			MemoryContext oldcontext = CurrentMemoryContext;
+			PG_TRY();
+			{
+				UnlockRelationOid(insert_exec_ctx.target_rel_oid, RowExclusiveLock);
+			}
+			PG_CATCH();
+			{
+				MemoryContextSwitchTo(oldcontext);
+				FlushErrorState();
+				/* Ignore unlock failures - table may have been dropped */
+			}
+			PG_END_TRY();
+		}
+		insert_exec_ctx.target_rel_oid = InvalidOid;
+	}
+
+	/* Reset the modification flag */
+	insert_exec_ctx.is_target_relation_modified = false;
+}
+
+/*
+ * Verify that the target table schema hasn't changed since INSERT EXEC started.
+ * Returns true if schema is unchanged, false if it has changed.
+ *
+ * This is called before flushing data to the target table to detect if the
+ * executed procedure altered the target table's schema.
+ *
+ * The is_target_relation_modified flag is set by the ObjectPostAlterHook
+ * when the target table is altered during INSERT EXEC execution.
+ */
+bool
+pltsql_insert_exec_verify_schema(void)
+{
+	/*
+	 * If the target relation OID is not valid, we can't verify.
+	 * This shouldn't happen in normal operation.
+	 */
+	if (!OidIsValid(insert_exec_ctx.target_rel_oid))
+		return true;
+
+	/*
+	 * Check if the target relation was modified during INSERT EXEC.
+	 * This flag is set by the ObjectPostAlterHook.
+	 */
+	return !insert_exec_ctx.is_target_relation_modified;
+}
+
+/*
+ * Set the flag indicating the target relation was modified.
+ * Called from ObjectPostAlterHook when the target table is altered.
+ */
+void
+pltsql_insert_exec_set_target_modified(void)
+{
+	insert_exec_ctx.is_target_relation_modified = true;
+}
+
+/*
+ * Get the target relation OID for INSERT EXEC.
+ * Used by ObjectPostAlterHook to check if the altered relation is the target.
+ */
+Oid
+pltsql_insert_exec_get_target_rel_oid(void)
+{
+	return insert_exec_ctx.target_rel_oid;
+}
+
+/*
+ * Helper function to check if a target list contains SELECT * (star expansion).
+ * Returns true if any target contains a star, false otherwise.
+ */
+static bool
+target_list_contains_star(List *targetList)
+{
+	ListCell *lc;
+
+	foreach(lc, targetList)
+	{
+		ResTarget *rt = (ResTarget *) lfirst(lc);
+
+		if (rt == NULL || !IsA(rt, ResTarget))
+			continue;
+
+		/* Check if the value is a ColumnRef with A_Star */
+		if (rt->val != NULL && IsA(rt->val, ColumnRef))
+		{
+			ColumnRef *cref = (ColumnRef *) rt->val;
+			ListCell *field_lc;
+
+			foreach(field_lc, cref->fields)
+			{
+				Node *field = (Node *) lfirst(field_lc);
+				if (IsA(field, A_Star))
+					return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Helper function to count target list columns in a SelectStmt.
+ * Handles UNION/INTERSECT/EXCEPT by recursively checking the left branch.
+ * Returns -1 if the statement is not a SELECT, if column count cannot be determined,
+ * or if the SELECT uses * (star expansion) which requires table resolution.
+ */
+static int
+count_select_target_columns(SelectStmt *stmt)
+{
+	if (stmt == NULL)
+		return -1;
+
+	/* For set operations (UNION, INTERSECT, EXCEPT), check the left branch */
+	if (stmt->op != SETOP_NONE)
+	{
+		return count_select_target_columns(stmt->larg);
+	}
+
+	/* For a simple SELECT, count the target list */
+	if (stmt->targetList != NULL)
+	{
+		/*
+		 * If the target list contains SELECT *, we can't determine the
+		 * actual column count without resolving the table reference.
+		 * Return -1 to skip early validation and let the normal path handle it.
+		 */
+		if (target_list_contains_star(stmt->targetList))
+			return -1;
+
+		return list_length(stmt->targetList);
+	}
+
+	return -1;
+}
+
+/*
+ * Validate column count from query string BEFORE plan preparation.
+ *
+ * T-SQL requires column mismatch errors to take priority over runtime errors
+ * like division by zero. PostgreSQL's plan preparation evaluates constant
+ * expressions, so we parse and count columns here without evaluation.
+ *
+ * This is an OPTIMIZATION for early error detection, not a correctness
+ * requirement. If we can't determine the column count (SELECT *, complex
+ * queries, parse errors), we skip early validation and let the normal
+ * execution path handle it - the DestReceiver will still catch mismatches.
+ *
+ * Returns true if validation passes OR cannot be performed (defer to normal path).
+ * Returns false only if column count mismatch is definitively detected.
+ */
+bool
+pltsql_insert_exec_validate_column_count_from_query(const char *query_string)
+{
+	List		*parsetree_list;
+	RawStmt		*raw_stmt;
+	Node		*stmt;
+	int			query_natts;
+	Oid			temp_table_oid;
+	Relation	temp_rel;
+	TupleDesc	temp_tupdesc;
+	int			temp_natts;
+	MemoryContext oldcontext;
+
+	/* Caller must ensure INSERT EXEC is active before calling */
+	Assert(pltsql_insert_exec_active());
+
+	/* Temp table must exist - caller checks pltsql_insert_exec_in_execution() */
+	temp_table_oid = pltsql_get_insert_exec_temp_table_oid();
+	Assert(OidIsValid(temp_table_oid));
+
+	/* Parse the query string - if parsing fails, defer to normal execution */
+	oldcontext = CurrentMemoryContext;
+	PG_TRY();
+	{
+		parsetree_list = raw_parser(query_string, RAW_PARSE_DEFAULT);
+	}
+	PG_CATCH();
+	{
+		MemoryContextSwitchTo(oldcontext);
+		FlushErrorState();
+		return true;  /* Parse error - normal path will report it */
+	}
+	PG_END_TRY();
+
+	/* Only handle single-statement queries */
+	if (list_length(parsetree_list) != 1)
+		return true;  /* Multiple statements, defer to runtime */
+
+	raw_stmt = (RawStmt *) linitial(parsetree_list);
+	stmt = raw_stmt->stmt;
+
+	/* Only validate SELECT statements */
+	if (!IsA(stmt, SelectStmt))
+		return true;  /* Not a SELECT (e.g., EXEC), defer to runtime */
+
+	/*
+	 * Count target list columns. Returns -1 for SELECT *, complex queries,
+	 * or when column count can't be determined statically. In those cases,
+	 * skip early validation - the DestReceiver will catch mismatches at runtime.
+	 */
+	query_natts = count_select_target_columns((SelectStmt *) stmt);
+	if (query_natts < 0)
+		return true;  /* Can't determine count statically, defer to runtime */
+
+	/* Get temp table column count */
+	PG_TRY();
+	{
+		temp_rel = table_open(temp_table_oid, AccessShareLock);
+		temp_tupdesc = RelationGetDescr(temp_rel);
+		temp_natts = temp_tupdesc->natts;
+		table_close(temp_rel, AccessShareLock);
+	}
+	PG_CATCH();
+	{
+		/* If we can't open the temp table, let normal path handle it */
+		MemoryContextSwitchTo(oldcontext);
+		FlushErrorState();
+		return true;
+	}
+	PG_END_TRY();
+
+	/* Check for column count mismatch */
+	if (query_natts != temp_natts)
+	{
+		/*
+		 * Set the error flag BEFORE throwing the error. This ensures that
+		 * even if TRY-CATCH catches the error, the flush will be skipped.
+		 *
+		 * Expected behavior: Column mismatch errors cause all rows to be
+		 * rolled back, even if caught by TRY-CATCH. This is different from
+		 * data-level errors like division by zero, which only affect the
+		 * current row and allow previously inserted rows to be kept.
+		 */
+		pltsql_insert_exec_set_error_flag();
+
+		/*
+		 * Use ERRCODE_DATATYPE_MISMATCH to avoid the error mapping in
+		 * error_mapping.txt. We want to keep the internal error code for
+		 * test compatibility.
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("Column name or number of supplied values does not match table definition.")));
+		return false;  /* Not reached, but for clarity */
+	}
+
+	return true;
+}
+
+/*
+ * Check if INSERT EXEC context is active (target table info is set).
+ * This returns true even before temp table is created.
+ */
+bool
+pltsql_insert_exec_active(void)
+{
+	return (insert_exec_ctx.target_table != NULL);
+}
+
+/*
+ * Stricter check than pltsql_insert_exec_active() - also verifies the temp
+ * table OID is valid. Returns false if context is stale or if temp table
+ * hasn't been created yet. Stale context is prevented by
+ * pltsql_clear_insert_exec_context() on every exit path.
+ */
+bool
+pltsql_insert_exec_in_execution(void)
+{
+	/*
+	 * call_stack_entry non-NULL + target_table non-NULL = INSERT EXEC is live.
+	 * Stale context is prevented by pltsql_clear_insert_exec_context() on
+	 * every exit path.
+	 */
+	if (insert_exec_ctx.target_table == NULL)
+		return false;
+
+	if (insert_exec_ctx.call_stack_entry == NULL)
+		return false;
+
+	/*
+	 * Check if the temp table OID is valid. Returns false early in INSERT EXEC
+	 * before temp table is created, which is fine.
+	 */
+	if (!OidIsValid(insert_exec_ctx.temp_table_oid))
+		return false;
+
+	return true;
+}
+
+/*
+ * Check if INSERT EXEC flush is in progress.
+ * During flush, we temporarily clear the INSERT EXEC context to allow
+ * INSTEAD OF triggers to fire, but we still need to block commit_stmt.
+ */
+bool
+pltsql_insert_exec_flush_in_progress(void)
+{
+	return insert_exec_ctx.flush_in_progress;
+}
+
+/*
+ * Set the INSERT EXEC flush in progress flag.
+ * Called when starting/ending the flush operation.
+ */
+void
+pltsql_insert_exec_set_flush_in_progress(bool in_progress)
+{
+	insert_exec_ctx.flush_in_progress = in_progress;
+}
+
+/*
+ * Get the temp table OID for INSERT EXEC buffering.
+ */
+Oid
+pltsql_get_insert_exec_temp_table_oid(void)
+{
+	return insert_exec_ctx.temp_table_oid;
+}
+
+/*
+ * Check if we're inside a TRY-CATCH block during INSERT EXEC.
+ * This checks the exec_state_call_stack to see if any estate has a TRY-CATCH block active.
+ */
+bool
+pltsql_insert_exec_in_trycatch(void)
+{
+	PLExecStateCallStack *cur;
+
+	if (insert_exec_ctx.target_table == NULL)
+		return false;
+
+	/* Check the call stack for any active TRY-CATCH blocks */
+	cur = exec_state_call_stack;
+	while (cur != NULL)
+	{
+		/* There is at-least one try block active for sure */
+		if (vec_size(cur->estate->err_ctx_stack) > 1)
+			return true;
+		/* Either try or catch block is active */
+		if (vec_size(cur->estate->err_ctx_stack) == 1)
+		{
+			PLtsql_errctx *err_ctx = *(PLtsql_errctx **) vec_at(cur->estate->err_ctx_stack, 0);
+
+			/* Make sure that we are not inside the catch block */
+			if (!err_ctx->partial_restored)
+				return true;
+		}
+		cur = cur->next;
+	}
+
+	return false;
+}
+
+/*
+ * Called from sigsetjmp handler when TRY-CATCH catches an error.
+ * Returns true if we should clean up INSERT EXEC context - only when the
+ * TRY-CATCH is at or above the INSERT EXEC level. If TRY-CATCH is inside
+ * the executed procedure (deeper stack), INSERT EXEC is still in progress.
+ */
+bool
+pltsql_insert_exec_should_cleanup_on_trycatch(void)
+{
+	if (insert_exec_ctx.target_table == NULL)
+		return false;
+
+	/*
+	 * If the call stack head is the same node as when INSERT EXEC started,
+	 * the error is at the INSERT EXEC level → clean up.
+	 * If it's a different (deeper) node, the error is inside the called
+	 * procedure → INSERT EXEC stays live.
+	 */
+	return exec_state_call_stack == insert_exec_ctx.call_stack_entry;
+}
+
+
+/*
+ * Create a DestReceiver for INSERT EXEC that writes to a temp table.
+ */
+DestReceiver *
+CreateInsertExecDestReceiver(Oid temp_table_oid)
+{
+	DR_insertexec *self = palloc0_object(DR_insertexec);
+
+	self->pub.receiveSlot = insertexec_receive;
+	self->pub.rStartup = insertexec_startup;
+	self->pub.rShutdown = insertexec_shutdown;
+	self->pub.rDestroy = insertexec_destroy;
+	self->pub.mydest = DestTransientRel;  /* reuse existing dest type */
+	self->temp_table_oid = temp_table_oid;
+
+	return (DestReceiver *) self;
+}
+
+/*
+ * insertexec_startup --- executor startup for INSERT EXEC receiver
+ *
+ * Relation is opened/closed per-tuple in insertexec_receive to avoid
+ * invalid handles after subtransaction rollbacks (e.g., TRY/CATCH).
+ *
+ * Validates column count matches the temp table and builds coercion
+ * expressions for type conversion using PostgreSQL's ExecBuildProjectionInfo/ExecProject.
+ */
+
+static void
+insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+	Relation	temp_rel;
+	TupleDesc	temp_tupdesc;
+	int			result_natts;
+	int			temp_natts;
+	int			i;
+	List	   *target_list = NIL;
+
+	/* Just store the tuple descriptor for later use */
+	myState->typeinfo = typeinfo;
+
+	/*
+	 * Validate column count: the number of columns in the result set
+	 * must match the number of columns in the temp table.
+	 * "Column name or number of supplied values does not match table definition."
+	 */
+	result_natts = typeinfo->natts;
+
+	/* Open temp table to get its tuple descriptor */
+	temp_rel = table_open(myState->temp_table_oid, AccessShareLock);
+	temp_tupdesc = RelationGetDescr(temp_rel);
+	temp_natts = temp_tupdesc->natts;
+
+	if (result_natts != temp_natts)
+	{
+		table_close(temp_rel, AccessShareLock);
+		/*
+		 * Set error flag BEFORE throwing to skip flush and re-throw even if
+		 * TRY-CATCH catches it. Column mismatch errors roll back all rows,
+		 * unlike data errors (e.g., divide by zero) which only affect current row.
+		 */
+		pltsql_insert_exec_set_error_flag();
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("Column name or number of supplied values does not match table definition.")));
+	}
+
+
+	for (i = 0; i < temp_natts; i++)
+	{
+		Form_pg_attribute src_att = TupleDescAttr(typeinfo, i);
+		Form_pg_attribute tgt_att = TupleDescAttr(temp_tupdesc, i);
+		Var		   *var;
+		Node	   *expr;
+		TargetEntry *tle;
+
+		/* Create Var node referencing input tuple column (OUTER_VAR for ecxt_outertuple) */
+		var = makeVar(OUTER_VAR,
+					  i + 1,				/* attnum is 1-based */
+					  src_att->atttypid,
+					  src_att->atttypmod,
+					  src_att->attcollation,
+					  0);					/* varlevelsup */
+
+		/*
+		 * coerce_to_target_type returns the Var unchanged when types match,
+		 * so we call it unconditionally.
+		 */
+		expr = coerce_to_target_type(NULL,
+									 (Node *) var,
+									 src_att->atttypid,
+									 tgt_att->atttypid,
+									 tgt_att->atttypmod,
+									 COERCION_ASSIGNMENT,
+									 COERCE_IMPLICIT_CAST,
+									 -1);
+
+		if (expr == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_CANNOT_COERCE),
+					 errmsg("cannot convert type %s to %s",
+							format_type_be(src_att->atttypid),
+							format_type_be(tgt_att->atttypid))));
+
+
+		/* Create TargetEntry for this column */
+		tle = makeTargetEntry((Expr *) expr,
+							  i + 1,		/* resno is 1-based */
+							  NULL,			/* resname */
+							  false);		/* resjunk */
+		target_list = lappend(target_list, tle);
+	}
+
+	/* Create expression context and projection info */
+	{
+		TupleDesc	proj_tupdesc;
+
+		myState->econtext = CreateStandaloneExprContext();
+
+		/* Copy descriptor - temp_rel is closed after startup, copy keeps it valid */
+		proj_tupdesc = CreateTupleDescCopy(temp_tupdesc);
+
+		/* Create the result slot for projection */
+		myState->proj_slot = MakeSingleTupleTableSlot(proj_tupdesc, &TTSOpsVirtual);
+
+		/* Build the projection info */
+		myState->proj_info = ExecBuildProjectionInfo(target_list,
+													 myState->econtext,
+													 myState->proj_slot,
+													 NULL,		/* no parent PlanState */
+													 typeinfo);	/* input descriptor */
+	}
+
+	table_close(temp_rel, AccessShareLock);
+
+	/*
+ 	 * Pre-assign XID before parallel mode starts. table_tuple_insert() calls
+ 	 * GetCurrentTransactionId() which fails in parallel mode if no XID exists.
+ 	 * rStartup runs before EnterParallelMode, so assigning here avoids the error.
+ 	*/
+
+	(void) GetCurrentTransactionId();  /* Ensure XID is assigned before parallel mode */
+
+	/* Obtain command ID once - all tuples share the same cid for MVCC consistency */
+	myState->cid = GetCurrentCommandId(true);
+}
+
+/*
+ * insertexec_receive --- receive one tuple and insert into temp table
+*/
+static bool
+insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+	Relation	temp_rel;
+	TupleTableSlot *insert_slot;
+
+	/* Open temp table fresh for each tuple */
+	temp_rel = table_open(myState->temp_table_oid, RowExclusiveLock);
+
+	ResetExprContext(myState->econtext);
+	myState->econtext->ecxt_outertuple = slot;
+	insert_slot = ExecProject(myState->proj_info);
+	table_tuple_insert(temp_rel, insert_slot, myState->cid, 0, NULL);
+
+	/* Close relation immediately - don't hold across subtransaction boundaries */
+	table_close(temp_rel, NoLock);
+
+	myState->rows_inserted++;
+
+	return true;
+}
+
+/*
+ * insertexec_shutdown --- executor end for INSERT EXEC receiver
+ *
+ * Clean up the expression context and projection slot used for type coercion.
+ */
+static void
+insertexec_shutdown(DestReceiver *self)
+{
+	DR_insertexec *myState = (DR_insertexec *) self;
+
+	Assert(myState->proj_slot != NULL);
+	ExecDropSingleTupleTableSlot(myState->proj_slot);
+	myState->proj_slot = NULL;
+
+	Assert(myState->econtext != NULL);
+	FreeExprContext(myState->econtext, true);
+	myState->econtext = NULL;
+}
+
+/*
+ * insertexec_destroy --- release DestReceiver object
+ */
+static void
+insertexec_destroy(DestReceiver *self)
+{
+	pfree(self);
+}
+
+/*
+ * Create a temp table for INSERT EXEC buffering.
+ *
+ * Creates a PostgreSQL temp table with schema matching
+ * the target table. Uses ChooseRelationName to generate a unique name
+ * that avoids conflicts. For regular tables, queries pg_attribute to get
+ * column definitions (avoids needing SELECT permission for ownership chaining).
+ */
+Oid
+create_insert_exec_temp_table(const char *target_table, const char *column_list, const char *schema_name_in)
+{
+	StringInfoData create_stmt;
+	int			rc;
+	Oid			temp_table_oid;
+	char	   *physical_schema = NULL;
+	MemoryContext oldcontext;
+	const char *select_cols;
+	char	   *cols_to_free = NULL;
+	char	   *qualified_target;
+	Oid			temp_nsp_oid;
+
+	/*
+	 * Generate a unique temp table name using ChooseRelationName.
+	 * This function checks pg_class for conflicts and appends a numeric
+	 * suffix if needed, ensuring uniqueness in the pg_temp namespace.
+	 */
+	temp_nsp_oid = LookupNamespaceNoError("pg_temp");
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+	insert_exec_ctx.temp_table_name = ChooseRelationName("__insert_exec_buf",
+														 NULL,
+														 "tmp",
+														 temp_nsp_oid,
+														 false);
+	MemoryContextSwitchTo(oldcontext);
+
+	if (insert_exec_ctx.temp_table_name == NULL)
+		elog(ERROR, "INSERT-EXEC: ChooseRelationName returned NULL");
+
+	/*
+	 * Parse schema and table name from target_table.
+	 * For temp tables (starting with #) and table variables (@),
+	 * no schema resolution is needed.
+	 */
+	if (!(target_table[0] == '#' || target_table[0] == '@'))
+	{
+		const char *sname = (schema_name_in != NULL) ? schema_name_in : "dbo";
+		physical_schema = get_physical_schema_name(get_cur_db_name(), sname);
+		if (physical_schema == NULL)
+			elog(ERROR, "INSERT-EXEC: Failed to resolve schema for target table: %s",
+				 target_table);
+	}
+
+	/*
+	 * Determine the column list to SELECT.
+	 *
+	 * If the user specified columns, use them directly.
+	 * Otherwise, query the relation to get all non-IDENTITY,
+	 * non-computed column names.
+	 */
+	if (column_list != NULL)
+	{
+		select_cols = column_list;
+	}
+	else
+	{
+		cols_to_free = get_insertable_column_list(target_table, physical_schema);
+		select_cols = cols_to_free;
+	}
+
+	/*
+	 * Build a fully qualified reference for the source table.
+	 * For temp tables and table variables, use the name directly.
+	 */
+	if (physical_schema != NULL)
+		qualified_target = psprintf("%s.%s",
+									quote_identifier(physical_schema),
+									quote_identifier(target_table));
+	else
+		qualified_target = pstrdup(quote_identifier(target_table));
+
+	/*
+	 * Create the temp buffer table by selecting the desired columns
+	 * with no rows. PostgreSQL infers column types from the SELECT.
+	 */
+	initStringInfo(&create_stmt);
+	appendStringInfo(&create_stmt,
+					 "CREATE TEMP TABLE %s AS SELECT %s FROM %s WITH NO DATA",
+					 quote_identifier(insert_exec_ctx.temp_table_name),
+					 select_cols, qualified_target);
+
+	if (cols_to_free)
+		pfree(cols_to_free);
+	pfree(qualified_target);
+
+	/* Clean up parsed names */
+	if (physical_schema)
+		pfree(physical_schema);
+
+	rc = SPI_execute(create_stmt.data, false, 0);
+	if (rc != SPI_OK_UTILITY)
+		elog(ERROR, "failed to create INSERT EXEC temp table: %s",
+			 SPI_result_code_string(rc));
+
+	pfree(create_stmt.data);
+
+	/* Get the OID of the created temp table */
+	temp_table_oid = RelnameGetRelid(insert_exec_ctx.temp_table_name);
+	if (!OidIsValid(temp_table_oid))
+		elog(ERROR, "could not find INSERT EXEC temp table %s",
+			 insert_exec_ctx.temp_table_name);
+
+	return temp_table_oid;
+}
+
+/*
+ * Drop the INSERT EXEC temp table.
+ * Uses the stored temp table name from the INSERT EXEC context.
+ */
+void
+drop_insert_exec_temp_table(Oid temp_table_oid)
+{
+	StringInfoData drop_stmt;
+	int			rc;
+
+	/* Use the stored temp table name from the context */
+	if (insert_exec_ctx.temp_table_name == NULL)
+	{
+		elog(DEBUG1, "INSERT-EXEC: No temp table name stored, cannot drop");
+		return;
+	}
+
+	initStringInfo(&drop_stmt);
+	appendStringInfo(&drop_stmt, "DROP TABLE IF EXISTS %s",
+					 quote_identifier(insert_exec_ctx.temp_table_name));
+
+	rc = SPI_execute(drop_stmt.data, false, 0);
+	if (rc != SPI_OK_UTILITY)
+		elog(WARNING, "failed to drop INSERT EXEC temp table %s: %s",
+			 insert_exec_ctx.temp_table_name, SPI_result_code_string(rc));
+
+	pfree(drop_stmt.data);
+
+	/* Clear the stored temp table name and OID */
+	pfree(insert_exec_ctx.temp_table_name);
+	insert_exec_ctx.temp_table_name = NULL;
+	insert_exec_ctx.temp_table_oid = InvalidOid;
+}
+
+/*
+ * Flush data from temp table to target table.
+ *
+ * Executes INSERT INTO target SELECT * FROM temp_table in a subtransaction.
+ * Uses SPI_execute for the flush INSERT.
+ * Switches to procedure owner's identity for ownership chaining.
+ */
+void
+flush_insert_exec_temp_table(PLtsql_execstate *estate)
+{
+	const char		*temp_table_name;
+	StringInfoData	flush_query;
+	int				rc;
+	const char		*target_table = insert_exec_ctx.target_table;
+	const char		*column_list = insert_exec_ctx.column_list;
+	Oid				temp_oid = pltsql_get_insert_exec_temp_table_oid();
+	MemoryContext	oldcontext = CurrentMemoryContext;
+	ResourceOwner	oldowner = CurrentResourceOwner;
+	volatile bool	subtxn_started = false;
+
+	/* Security context for ownership chaining */
+	Oid				flush_save_userid = InvalidOid;
+	int				flush_save_sec_context = 0;
+	volatile bool	flush_switched_context = false;
+
+	if (!OidIsValid(temp_oid) || target_table == NULL)
+	{
+		return;
+	}
+
+	/*
+	 * Check if an error occurred during INSERT EXEC that should prevent flush.
+	 * Column mismatch errors cause all rows to be rolled back, even if caught
+	 * by TRY-CATCH.
+	 */
+	if (pltsql_insert_exec_had_error())
+		return;
+
+	/*
+	 * Verify target table schema hasn't changed since INSERT EXEC started.
+	 */
+	if (!pltsql_insert_exec_verify_schema())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("INSERT EXEC failed because the stored procedure altered the schema of the target table.")));
+	}
+
+	/*
+	 * Save the INSERT EXEC context info before clearing it.
+	 * We need to temporarily clear the context so that the flush INSERT
+	 * behaves like a normal INSERT and fires INSTEAD OF triggers properly.
+	 */
+
+	/* Get the dynamically chosen temp table name from the context */
+	temp_table_name = insert_exec_ctx.temp_table_name;
+	if (temp_table_name == NULL)
+	{
+		elog(ERROR, "INSERT-EXEC: No temp table name stored, cannot flush");
+	}
+
+	initStringInfo(&flush_query);
+
+	if (column_list != NULL)
+	{
+		/*
+		 * User specified columns - use them directly.
+		 * The temp table was created with columns in the same order as the
+		 * user's column list, so SELECT * gives values in the correct order.
+		 */
+		appendStringInfo(&flush_query,
+			"INSERT INTO %s (%s) SELECT * FROM %s",
+			target_table,
+			column_list,
+			quote_identifier(temp_table_name));
+	}
+	else
+	{
+		appendStringInfo(&flush_query,
+			"INSERT INTO %s SELECT * FROM %s",
+			target_table,
+			quote_identifier(temp_table_name));
+	}
+
+	/*
+	 * Execute the flush INSERT in its own subtransaction that commits
+	 * immediately. This is critical for TRY-CATCH behavior.
+	 *
+	 * We route through exec_stmt_execsql to reuse the standard SQL execution
+	 * path which handles triggers, rowcount, and FOUND properly.
+	 */
+	PG_TRY();
+	{
+		BeginInternalSubTransaction("insert_exec_flush");
+		subtxn_started = true;
+		MemoryContextSwitchTo(oldcontext);
+
+		pltsql_insert_exec_set_flush_in_progress(true);
+
+		/* Switch to procedure owner for ownership chaining */
+		if (estate && estate->func && OidIsValid(estate->func->fn_oid))
+		{
+			GetUserIdAndSecContext(&flush_save_userid, &flush_save_sec_context);
+			SetUserIdAndSecContext(get_func_owner(estate->func->fn_oid),
+								   flush_save_sec_context | SECURITY_LOCAL_USERID_CHANGE);
+			flush_switched_context = true;
+		}
+
+		/* Execute the flush INSERT using SPI */
+		rc = SPI_execute(flush_query.data, false, 0);
+
+		/* Restore security context immediately after execution */
+		if (flush_switched_context)
+		{
+			SetUserIdAndSecContext(flush_save_userid, flush_save_sec_context);
+			flush_switched_context = false;
+		}
+
+		if (rc != SPI_OK_INSERT && rc != SPI_OK_INSERT_RETURNING)
+			elog(ERROR, "INSERT-EXEC: Failed to flush temp table to target");
+
+		/* Update rowcount and FOUND for T-SQL compatibility */
+		estate->eval_processed = SPI_processed;
+		exec_set_rowcount(SPI_processed);
+		exec_set_found(estate, SPI_processed != 0);
+
+		/* Clear the flush flag after successful flush */
+		pltsql_insert_exec_set_flush_in_progress(false);
+
+		/* Commit the flush subtransaction - this "locks in" the data */
+		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+	}
+	PG_CATCH();
+	{
+		/* Restore security context on error if it was switched */
+		if (flush_switched_context)
+		{
+			SetUserIdAndSecContext(flush_save_userid, flush_save_sec_context);
+			flush_switched_context = false;
+		}
+
+		/* Clear the flush flag on error */
+		pltsql_insert_exec_set_flush_in_progress(false);
+
+		/* Roll back the flush subtransaction on error */
+		if (subtxn_started)
+		{
+			RollbackAndReleaseCurrentSubTransaction();
+		}
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+
+		pfree(flush_query.data);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	pfree(flush_query.data);
+}
+
+/*
+ * insert_exec_setup - Initialize INSERT EXEC context and create temp table.
+ *
+ * If start_implicit_txn is true, starts an implicit transaction for stored
+ * procedure calls. Returns the temp table OID via temp_table_oid_out.
+ * Throws an error if nested INSERT EXEC is detected.
+ */
+bool
+insert_exec_setup(PLtsql_execstate *estate,
+                  const char *target_table,
+                  const char *schema_name,
+                  const char *db_name,
+                  const char *column_list,
+                  bool start_implicit_txn,
+                  Oid *temp_table_oid_out)
+{
+	Oid temp_table_oid;
+
+	/* Initialize output */
+	*temp_table_oid_out = InvalidOid;
+
+	/* Check for nested INSERT EXEC */
+	if (pltsql_insert_exec_active())
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("nested INSERT ... EXECUTE statements are not allowed")));
+	}
+
+	/*
+	 * Start implicit transaction for INSERT EXEC if requested and not already in one.
+	 * This is used for stored procedure calls (exec_stmt_exec) but not for
+	 * dynamic SQL (exec_stmt_exec_batch) which has different transaction semantics.
+	 */
+	if (start_implicit_txn)
+	{
+		bool in_function = (estate->func &&
+							estate->func->fn_oid != InvalidOid &&
+							estate->func->fn_prokind == PROKIND_FUNCTION &&
+							estate->func->fn_is_trigger == PLTSQL_NOT_TRIGGER);
+
+		if (!pltsql_disable_batch_auto_commit &&
+			pltsql_support_tsql_transactions() &&
+			!IsTransactionBlockActive() &&
+			!in_function)
+		{
+			elog(DEBUG4, "TSQL TXN Start internal transaction for INSERT EXEC");
+			pltsql_start_txn();
+			pltsql_insert_exec_set_implicit_txn_flag();
+			estate->tsql_trigger_flags |= TSQL_TRAN_STARTED;
+		}
+	}
+
+	/* Set global context info for flush function */
+	pltsql_set_insert_exec_context_info(target_table, column_list);
+
+	/* Hold target table open to detect schema alterations during execution */
+	pltsql_insert_exec_open_target_table(target_table, schema_name, db_name);
+
+	/* Create temp table based on target table structure */
+	temp_table_oid = create_insert_exec_temp_table(target_table, column_list, schema_name);
+
+	/* Set global context so DestReceiver knows where to write */
+	pltsql_set_insert_exec_context(temp_table_oid);
+
+	*temp_table_oid_out = temp_table_oid;
+	return true;
+}
+
+/*
+ * insert_exec_error_cleanup - Clean up INSERT EXEC state on error.
+ *
+ * Sets error flag, clears implicit transaction flag, closes target table,
+ * and clears the context.
+ */
+void
+insert_exec_error_cleanup(bool setup_done)
+{
+	if (setup_done)
+	{
+		pltsql_insert_exec_set_error_flag();
+		pltsql_insert_exec_clear_implicit_txn_flag();
+		pltsql_insert_exec_close_target_table();
+		pltsql_clear_insert_exec_context();
+	}
+	else if (pltsql_insert_exec_active())
+	{
+		/* Cleanup partially initialized context from setup failure */
+		pltsql_insert_exec_set_error_flag();
+		pltsql_insert_exec_clear_implicit_txn_flag();
+		pltsql_insert_exec_close_target_table();
+		pltsql_clear_insert_exec_context();
+	}
+}
+
+/*
+ * insert_exec_success_cleanup - Clean up INSERT EXEC after successful execution.
+ *
+ * Flushes temp table to target, drops temp table, clears context,
+ * and commits the implicit transaction if one was started.
+ */
+void
+insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid)
+{
+	MemoryContext oldcontext = CurrentMemoryContext;
+	ResourceOwner oldowner = CurrentResourceOwner;
+
+	/*
+	 * Flush temp table to target table and cleanup after procedure completes.
+	 */
+	PG_TRY();
+	{
+		/* Flush temp table to target table */
+		flush_insert_exec_temp_table(estate);
+
+		/* Close target table after flush completes */
+		pltsql_insert_exec_close_target_table();
+	}
+	PG_CATCH();
+	{
+		/*
+		 * Close target table and drop temp table before clearing context.
+		 * Also clear the implicit transaction flag since the transaction
+		 * will be rolled back due to the flush error.
+		 */
+		pltsql_insert_exec_close_target_table();
+		drop_insert_exec_temp_table(temp_table_oid);
+		pltsql_insert_exec_clear_implicit_txn_flag();
+		pltsql_clear_insert_exec_context();
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+
+	/* Drop temp table in separate subtransaction */
+	BeginInternalSubTransaction(NULL);
+	MemoryContextSwitchTo(oldcontext);
+
+	PG_TRY();
+	{
+		drop_insert_exec_temp_table(temp_table_oid);
+		ReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+	}
+	PG_CATCH();
+	{
+		/* DROP failed - log warning but don't fail the INSERT EXEC */
+		RollbackAndReleaseCurrentSubTransaction();
+		MemoryContextSwitchTo(oldcontext);
+		CurrentResourceOwner = oldowner;
+		elog(WARNING, "INSERT EXEC: failed to drop temp table, will be cleaned up at transaction end");
+		FlushErrorState();
+	}
+	PG_END_TRY();
+
+	/*
+	 * Clear the INSERT EXEC context AFTER the drop completes.
+	 * This must be last because it frees temp_table_name which drop needs.
+	 */
+	pltsql_clear_insert_exec_context();
+
+	/*
+	 * Commit the implicit transaction that was started for INSERT EXEC.
+	 */
+	if (pltsql_insert_exec_started_implicit_txn())
+	{
+		elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
+		commit_stmt(estate, true);
+		pltsql_insert_exec_clear_implicit_txn_flag();
+	}
+
+	/* Clear the TSQL_TRAN_STARTED flag */
+	estate->tsql_trigger_flags &= ~TSQL_TRAN_STARTED;
+}

--- a/contrib/babelfishpg_tsql/src/pltsql-2.h
+++ b/contrib/babelfishpg_tsql/src/pltsql-2.h
@@ -3,6 +3,19 @@
 #include "pg_config_manual.h"
 
 /*
+ * INSERT EXEC info - shared by PLtsql_stmt_exec, PLtsql_stmt_exec_sp,
+ * and PLtsql_stmt_exec_batch.
+ */
+typedef struct InsertExecInfo
+{
+    bool        is_insert_exec;     /* Is this INSERT EXEC? */
+    char       *target;             /* Target table name (bare name only, no schema/db prefix) */
+    char       *schema;             /* Schema name, or NULL if not specified */
+    char       *db_name;            /* Database name, or NULL if not specified */
+    char       *columns;            /* Column list for INSERT-EXEC */
+} InsertExecInfo;
+
+/*
  * PRINT statement
  */
 typedef struct
@@ -90,6 +103,8 @@ typedef struct PLtsql_stmt_exec
 	char	   *db_name;
 	char	   *proc_name;
 	char	   *schema_name;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 		
 	bool		exec_with_recompile; /* forced recompile through EXECUTE */	
 } PLtsql_stmt_exec;
@@ -145,6 +160,8 @@ typedef struct PLtsql_stmt_exec_sp
 	PLtsql_expr *opt2;
 	PLtsql_expr *opt3;
 	List	   *stropt;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 } PLtsql_stmt_exec_sp;
 
 /*
@@ -165,6 +182,8 @@ typedef struct PLtsql_stmt_exec_batch
 	PLtsql_stmt_type cmd_type;
 	int			lineno;
 	PLtsql_expr *expr;
+
+	InsertExecInfo insert_exec;	/* INSERT EXEC info */
 } PLtsql_stmt_exec_batch;
 
 typedef struct PLtsql_stmt_raiserror

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1537,12 +1537,6 @@ typedef struct PLtsql_execstate
 
 	int			tsql_trigger_flags;
 
-	/*
-	 * A same procedure can be invoked by either normal EXECUTE or INSERT ...
-	 * EXECUTE, and can behave differently.
-	 */
-	bool		insert_exec;
-
 	List	   *explain_infos;
 	instr_time	planning_start;
 	instr_time	planning_end;
@@ -1824,6 +1818,9 @@ typedef struct PLtsql_protocol_plugin
 	Datum       (*sql_geometry_from_bytea) (PG_FUNCTION_ARGS);
 	
 	Datum       (*sql_geography_from_bytea) (PG_FUNCTION_ARGS);
+
+	/* INSERT EXEC support */
+	bool		(*pltsql_insert_exec_active) (void);
 
 	/* Session level GUCs */
 	bool		quoted_identifier;
@@ -2228,6 +2225,7 @@ extern void pltsql_start_txn(void);
 extern void pltsql_commit_txn(void);
 extern void pltsql_rollback_txn(void);
 extern void pltsql_abort_any_transaction(void);
+extern void commit_stmt(PLtsql_execstate *estate, bool txnStarted);
 extern bool pltsql_get_errdata(int *tsql_error_code, int *tsql_error_severity, int *tsql_error_state);
 extern void pltsql_eval_txn_data(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt, CachedPlanSource *cachedPlanSource);
 extern bool is_sysname_column(ColumnDef *coldef);
@@ -2389,6 +2387,69 @@ extern bool 	is_numeric_datatype(Oid typid);
  * Function in pltsql_ruleutils.c
  */
 extern char *tsql_format_type_extended(Oid type_oid, int32 typemod, bits16 flags);
+
+/*
+ * INSERT EXEC functions (pl_insert_exec.c)
+ */
+extern void pltsql_set_insert_exec_context_info(const char *target_table, const char *column_list);
+extern void pltsql_set_insert_exec_context(Oid temp_table_oid);
+extern void pltsql_clear_insert_exec_context(void);
+extern void pltsql_insert_exec_reset_all(void);
+extern bool pltsql_insert_exec_active(void);
+extern bool pltsql_insert_exec_in_execution(void);
+extern bool pltsql_insert_exec_flush_in_progress(void);
+extern void pltsql_insert_exec_set_flush_in_progress(bool in_progress);
+extern Oid pltsql_get_insert_exec_temp_table_oid(void);
+extern bool pltsql_insert_exec_in_trycatch(void);
+extern bool pltsql_insert_exec_should_cleanup_on_trycatch(void);
+extern void pltsql_insert_exec_set_error_flag(void);
+extern bool pltsql_insert_exec_had_error(void);
+extern void pltsql_insert_exec_clear_error_flag(void);
+extern void pltsql_insert_exec_set_implicit_txn_flag(void);
+extern bool pltsql_insert_exec_started_implicit_txn(void);
+extern void pltsql_insert_exec_clear_implicit_txn_flag(void);
+extern void pltsql_insert_exec_open_target_table(const char *target_table,const char *schema_name_in,
+                                                  const char *db_name_in);
+extern void pltsql_insert_exec_close_target_table(void);
+extern bool pltsql_insert_exec_verify_schema(void);
+extern void pltsql_insert_exec_set_target_modified(void);
+extern Oid pltsql_insert_exec_get_target_rel_oid(void);
+extern bool pltsql_insert_exec_validate_column_count_from_query(const char *query_string);
+
+/* Transaction helper - used by INSERT EXEC for implicit transaction commit */
+extern void commit_stmt(PLtsql_execstate *estate, bool txnStarted);
+
+/* SQL execution helper - used by INSERT EXEC for flush */
+extern int exec_stmt_execsql(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
+
+/* INSERT EXEC helper functions */
+extern bool insert_exec_setup(PLtsql_execstate *estate,
+                              const char *target_table,
+                              const char *schema_name,
+                              const char *db_name,
+                              const char *column_list,
+                              bool start_implicit_txn,
+                              Oid *temp_table_oid_out);
+extern void insert_exec_error_cleanup(bool setup_done);
+extern void insert_exec_success_cleanup(PLtsql_execstate *estate, Oid temp_table_oid);
+extern bool parse_insert_exec_table_name(const char *target_table,
+										 char **schema_name_out,
+										 char **table_name_out,
+										 char **physical_schema_out,
+										 bool get_physical);
+extern DestReceiver *CreateInsertExecDestReceiver(Oid temp_table_oid);
+extern Oid create_insert_exec_temp_table(const char *target_table,
+                                          const char *column_list,
+                                          const char *schema_name_in);
+extern void drop_insert_exec_temp_table(Oid temp_table_oid);
+extern void flush_insert_exec_temp_table(PLtsql_execstate *estate);
+
+// extern void setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
+
+extern bool is_part_of_pltsql_trycatch_block(PLtsql_execstate *estate);
+
+/* Helper to unwrap implicit casts from a node */
+extern Node *get_underlying_node_from_implicit_casting(Node *n, NodeTag underlying_nodetype);
 
 #define NUM_DB_OBJECTS 11
 

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -126,10 +126,15 @@ PLTsqlProcessTransaction(Node *parsetree,
 
 		case TRANS_STMT_COMMIT:
 			{
-				if (exec_state_call_stack &&
-					exec_state_call_stack->estate &&
-					exec_state_call_stack->estate->insert_exec &&
-					NestedTranCount <= 1)
+				/*
+				 * Block COMMIT during INSERT EXEC if NestedTranCount <= 1.
+				 * 
+				 * INSERT EXEC implicitly makes @@TRANCOUNT = 1. COMMIT is only
+				 * blocked if it would make @@TRANCOUNT go from 1 to 0. If the
+				 * procedure did BEGIN TRAN first (@@TRANCOUNT = 2), then COMMIT
+				 * is allowed (@@TRANCOUNT goes from 2 to 1).
+				 */
+				if (pltsql_insert_exec_active() && NestedTranCount <= 1)
 					ereport(ERROR,
 							(errcode(ERRCODE_TRANSACTION_ROLLBACK),
 							 errmsg("Cannot use the COMMIT statement within an INSERT-EXEC statement unless BEGIN TRANSACTION is used first.")));
@@ -140,9 +145,11 @@ PLTsqlProcessTransaction(Node *parsetree,
 
 		case TRANS_STMT_ROLLBACK:
 			{
-				if (exec_state_call_stack &&
-					exec_state_call_stack->estate &&
-					exec_state_call_stack->estate->insert_exec)
+				/*
+				 * Block ROLLBACK during INSERT EXEC.
+				 * ROLLBACK is not allowed within an INSERT-EXEC statement.
+				 */
+				if (pltsql_insert_exec_active())
 					ereport(ERROR,
 							(errcode(ERRCODE_TRANSACTION_ROLLBACK),
 							 errmsg("Cannot use the ROLLBACK statement within an INSERT-EXEC statement.")));

--- a/contrib/babelfishpg_tsql/src/session.c
+++ b/contrib/babelfishpg_tsql/src/session.c
@@ -3,6 +3,7 @@
 #include "miscadmin.h"
 #include "varatt.h"
 
+#include "access/parallel.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/formatting.h"
@@ -256,17 +257,24 @@ set_search_path_for_user_schema(const char *db_name, const char *user)
 		pfree(current_db_search_path);
 	current_db_search_path = MemoryContextStrdup(TopMemoryContext, path);
 
-	/* set search path default so transaction rollback does not affect it */
-	SetConfigOption("search_path", path,
-					PGC_SUSET, PGC_S_SESSION);
 	/*
-	 * Incase of error inside parallel worker we could reach here before transaction
-	 * abort. Do not try to set_config since it will fail inside a parallel worker
-	 * This function is used in code path where error is never expected
+	 * Skip setting search_path if in parallel mode - parallel workers cannot
+	 * set GUC parameters. This is needed for INSERT EXEC with parallel query.
 	 */
-	if (!IsAbortedTransactionBlockState())
+	if (!IsInParallelMode())
+	{
+		/* set search path default so transaction rollback does not affect it */
 		SetConfigOption("search_path", path,
-						PGC_SUSET, PGC_S_DATABASE_USER);
+						PGC_SUSET, PGC_S_SESSION);
+		/*
+		 * Incase of error inside parallel worker we could reach here before transaction
+		 * abort. Do not try to set_config since it will fail inside a parallel worker
+		 * This function is used in code path where error is never expected
+		 */
+		if (!IsAbortedTransactionBlockState())
+			SetConfigOption("search_path", path,
+							PGC_SUSET, PGC_S_DATABASE_USER);
+	}
 	
 	pfree(path);
 	pfree(dbo_schema_name);

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -119,6 +119,7 @@ PLtsql_stmt *makeCfl(TSqlParser::Cfl_statementContext *ctx, tsqlBuilder &builder
 PLtsql_stmt *makeSQL(ParserRuleContext *ctx);
 std::vector<PLtsql_stmt *> makeAnother(TSqlParser::Another_statementContext *ctx, tsqlBuilder &builder);
 PLtsql_stmt *makeExecBodyBatch(TSqlParser::Execute_body_batchContext *ctx);
+PLtsql_stmt *makeExecuteStatement(TSqlParser::Execute_statementContext *ctx);
 PLtsql_stmt *makeExecuteProcedure(ParserRuleContext *ctx, std::string call_type);
 PLtsql_stmt *makeInsertBulkStatement(TSqlParser::Dml_statementContext *ctx);
 PLtsql_stmt *makeDbccCheckidentStatement(TSqlParser::Dbcc_statementContext *ctx);
@@ -1624,6 +1625,83 @@ public:
 		setCode(container, list_delete_ptr(siblings, stmt));
 	}
 
+	/*
+	 * Apply expression rewriting for INSERT EXEC statements.
+	 * Converts double-quoted strings to single-quoted strings
+	 * (e.g., "master" -> 'master') for PostgreSQL compatibility.
+	 * PLTSQL_STMT_EXEC_SP does not need rewriting — system SP arguments
+	 * are explicit typed parameters, not general SQL expressions.
+	*/
+	void applyInsertExecRewriting(PLtsql_stmt *base_stmt,
+                               TSqlParser::Execute_statementContext *ctxES)
+	{
+    	if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+    	{
+        	PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+        	PLtsql_expr_query_mutator mutator(exec_stmt->expr, ctxES);
+        	add_rewritten_query_fragment_to_mutator(&mutator);
+        	mutator.run();
+    	}
+		else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+		{
+			PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+			PLtsql_expr_query_mutator mutator(exec_batch_stmt->expr, ctxES);
+			/*
+			* We don't call markSelectFragment here — selectFragmentOffsets was
+			* recorded with ctx->parent as key, not ctxES. For dynamic SQL in
+			* INSERT EXEC, we rewrite the entire expression string.
+			*/
+			add_rewritten_query_fragment_to_mutator(&mutator);
+			mutator.run();
+		}
+	}
+
+	/*
+	 * Replace a grafted statement with a new one.
+	 * Used for INSERT EXEC where we replace PLtsql_stmt_execsql with PLtsql_stmt_exec
+	 */
+	void replaceGraftedStatement(ParserRuleContext *ctx, PLtsql_stmt *new_stmt)
+	{
+		PLtsql_stmt *old_stmt = getPLtsql_fragment(ctx);
+		ParserRuleContext *container = peekContainer();
+
+		if (old_stmt && container)
+		{
+			List *siblings = getCode(container);
+			ListCell *lc;
+			int pos = 0;
+
+			if (pltsql_enable_antlr_detailed_log)
+				std::cout << "    replacing stmt (" << (void *) old_stmt << ") with (" << (void *) new_stmt << ") in container(" << (void *) container << ")" << std::endl;
+
+			/* Find the position of the old statement */
+			foreach(lc, siblings)
+			{
+				if (lfirst(lc) == old_stmt)
+					break;
+				pos++;
+			}
+
+			/* Remove old statement and insert new one at the same position */
+			siblings = list_delete_ptr(siblings, old_stmt);
+			siblings = list_insert_nth(siblings, pos, new_stmt);
+			setCode(container, siblings);
+
+			/* Update the fragment mapping */
+			attachPLtsql_fragment(ctx, new_stmt);
+		}
+		else
+		{
+    		/*
+    		 * old_stmt is always set for INSERT EXEC — exitDml_statement attaches
+    		 * a PLtsql_stmt_execsql fragment before this function is called.
+    		* Reaching here means a broken parser state.
+    		*/
+    		Assert(false);
+		}
+
+	}
+
 	//////////////////////////////////////////////////////////////////////////////
 	// Container statement management
 	//////////////////////////////////////////////////////////////////////////////
@@ -1947,32 +2025,160 @@ public:
 		process_execsql_remove_unsupported_tokens(ctx, statementMutator.get());
 
 		// record whether the stmt is an INSERT-EXEC stmt
-		stmt->insert_exec =
+		bool is_insert_exec =
 			ctx->insert_statement() &&
 			ctx->insert_statement()->insert_statement_value() &&
 			ctx->insert_statement()->insert_statement_value()->execute_statement();
 
-		if (stmt->insert_exec)
+		if (is_insert_exec)
 		{
-			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
-			TSqlParser::Execute_bodyContext *body = nullptr;
-
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
-			body = ctxES->execute_body();
-			Assert(body);
-			
-			ctx_name       = body->func_proc_name_server_database_schema();
-			if (ctx_name) 
-			{				
-				if (ctx_name->database)
+			/*
+			 * Check if we're inside a function - INSERT EXEC is not allowed in functions
+			 * unless the target is a table variable (local_id).
+			 */
+			if (is_compiling_create_function())
+			{
+				auto ddl_object = ctx->insert_statement()->ddl_object();
+				if (ddl_object && !ddl_object->local_id())
 				{
-					db_name = stripQuoteFromId(ctx_name->database);
-					is_cross_db = true;
+					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION,
+						"'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
 				}
-				if (ctx_name->schema)
-					schema_name = stripQuoteFromId(ctx_name->schema);
 			}
+
+			/*
+			 * The OUTPUT clause cannot be used in an INSERT...EXEC statement.
+			 * Check for OUTPUT clause and throw error if present.
+			 */
+			if (ctx->insert_statement()->output_clause())
+			{
+				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+					"The OUTPUT clause cannot be used in an INSERT...EXEC statement.",
+					getLineAndPos(ctx->insert_statement()->output_clause()));
+			}
+
+			/*
+			 * Instead of creating a PLtsql_stmt_execsql for
+			 * "INSERT INTO t EXEC p", we create a PLtsql_stmt_exec for just "EXEC p"
+			 * and set the INSERT EXEC fields. This allows exec_stmt_exec to handle
+			 * the temp table lifecycle and avoids parser-level issues.
+			 *
+			 * Note: makeExecuteStatement returns either PLtsql_stmt_exec (for procedure calls)
+			 * or PLtsql_stmt_exec_batch (for dynamic SQL like EXEC(@variable)). We need to
+			 * handle both cases and set the INSERT EXEC fields on the correct struct.
+			 */
+			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
+			
+			/* Create the EXEC statement - could be PLtsql_stmt_exec or PLtsql_stmt_exec_batch */
+			PLtsql_stmt *base_stmt = makeExecuteStatement(ctxES);
+
+			/* Extract target table name, schema, and database separately */
+			std::string tbl_name, tbl_schema, tbl_db;
+			auto ddl_object = ctx->insert_statement()->ddl_object();
+			if (ddl_object)
+			{
+				if (ddl_object->local_id())
+				{
+					/* Table variable like @tablevar - no schema or db */
+					tbl_name = ::getFullText(ddl_object->local_id());
+				}
+				else if (ddl_object->full_object_name())
+				{
+					if (ddl_object->full_object_name()->object_name)
+						tbl_name = stripQuoteFromId(ddl_object->full_object_name()->object_name);
+					if (ddl_object->full_object_name()->schema)
+						tbl_schema = stripQuoteFromId(ddl_object->full_object_name()->schema);
+					if (ddl_object->full_object_name()->database)
+						tbl_db = stripQuoteFromId(ddl_object->full_object_name()->database);
+
+					/*
+					* Temp tables live in pg_temp, not user schemas. Strip any schema
+					* prefix the user may have provided (e.g., dbo.#temp).
+					*/
+					if (!tbl_name.empty() && tbl_name[0] == '#')
+					{
+						tbl_schema.clear();
+						tbl_db.clear();
+					}
+				}
+			}
+
+			/* Extract column list */
+			std::string column_list;
+			auto column_list_ctx = ctx->insert_statement()->insert_column_name_list();
+			if (column_list_ctx)
+			{
+				bool first = true;
+				for (auto col : column_list_ctx->col)
+				{
+					if (!first)
+						column_list += ", ";
+					first = false;
+					auto ids = col->id();
+					/* A column reference always has at least one identifier token per grammar */
+        			Assert(!ids.empty());
+					if (!ids.empty() && ids.back() != nullptr)
+						column_list += stripQuoteFromId(ids.back());
+				}
+			}
+
+			/*
+			 * target_table must be set for INSERT EXEC — if it's empty here,
+			 * the parse tree is malformed (ddl_object missing or has no object name).
+			 */
+			if (tbl_name.empty())
+				throw PGErrorWrapperException(ERROR, ERRCODE_SYNTAX_ERROR,
+					"INSERT EXEC requires a valid target table",
+					getLineAndPos(ctx->insert_statement()->ddl_object()));
+
+			/*
+			 * Helper lambda to set INSERT EXEC fields on the statement.
+			 * This avoids duplicating the same 5-line block for each statement type.
+			 */
+			auto setInsertExecInfo = [&](InsertExecInfo *info) {
+				info->is_insert_exec = true;
+				info->target = pstrdup(tbl_name.c_str());
+				if (!tbl_schema.empty())
+					info->schema = pstrdup(tbl_schema.c_str());
+				if (!tbl_db.empty())
+					info->db_name = pstrdup(tbl_db.c_str());
+				if (!column_list.empty())
+					info->columns = pstrdup(column_list.c_str());
+			};
+
+			/* Set INSERT EXEC fields based on the actual statement type */
+			if (base_stmt->cmd_type == PLTSQL_STMT_EXEC)
+			{
+				/* Procedure call: EXEC proc_name */
+				PLtsql_stmt_exec *exec_stmt = (PLtsql_stmt_exec *) base_stmt;
+				setInsertExecInfo(&exec_stmt->insert_exec);
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_BATCH)
+			{
+				/* Dynamic SQL: EXEC(@variable) or EXEC('string') */
+				PLtsql_stmt_exec_batch *exec_batch_stmt = (PLtsql_stmt_exec_batch *) base_stmt;
+				setInsertExecInfo(&exec_batch_stmt->insert_exec);
+			}
+			else if (base_stmt->cmd_type == PLTSQL_STMT_EXEC_SP)
+			{
+				/* System stored procedure: EXEC sp_executesql, sp_execute, sp_prepexec */
+				PLtsql_stmt_exec_sp *exec_sp_stmt = (PLtsql_stmt_exec_sp *) base_stmt;
+				setInsertExecInfo(&exec_sp_stmt->insert_exec);
+			}
+
+			applyInsertExecRewriting(base_stmt, ctxES);
+
+			/* Replace the PLtsql_stmt_execsql with the exec statement in the container */
+			replaceGraftedStatement(ctx, base_stmt);
+
+			/* Clear the mutator since we're not using the execsql statement */
+			statementMutator.reset();
+			clear_rewritten_query_fragment();
+			return;
 		}
+
+		/* For non-INSERT-EXEC statements, continue with normal processing */
+		stmt->insert_exec = false;
 
 		// record whether stmt is cross-db
 		if (is_cross_db)

--- a/test/JDBC/expected/BABEL-2999-vu-verify.out
+++ b/test/JDBC/expected/BABEL-2999-vu-verify.out
@@ -145,14 +145,14 @@ insert into t3_BABEL2999_2 exec('select ''123''');
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: structure of query does not match function result type)~~
+~~ERROR (Message: Column name or number of supplied values does not match table definition.)~~
 
 
 insert into t3_BABEL2999_2 exec('select 123, 123');
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: structure of query does not match function result type)~~
+~~ERROR (Message: Column name or number of supplied values does not match table definition.)~~
 
 
 insert into t4_BABEL2999 exec('select 123, 123, 123, 123, 123')

--- a/test/JDBC/expected/BABEL-INSERT-EXEC.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXEC.out
@@ -1,0 +1,1205 @@
+-- ============================================================================
+-- BABEL-INSERT-EXEC: Comprehensive test for INSERT INTO ... EXEC functionality
+-- Tests the Temp Table + Query Rewriting approach for INSERT EXEC
+-- ============================================================================
+-- ============================================================================
+-- Cleanup any leftover objects from previous failed runs
+-- ============================================================================
+DROP PROCEDURE IF EXISTS insert_exec_p1;
+DROP PROCEDURE IF EXISTS insert_exec_p2;
+DROP PROCEDURE IF EXISTS insert_exec_p3;
+DROP PROCEDURE IF EXISTS insert_exec_p4;
+DROP PROCEDURE IF EXISTS insert_exec_p5;
+DROP PROCEDURE IF EXISTS insert_exec_pb1;
+DROP PROCEDURE IF EXISTS insert_exec_ptypes;
+DROP PROCEDURE IF EXISTS insert_exec_pnulls;
+DROP PROCEDURE IF EXISTS insert_exec_pcoerce;
+DROP PROCEDURE IF EXISTS insert_exec_pdynamic;
+DROP PROCEDURE IF EXISTS insert_exec_pmultidyn;
+DROP PROCEDURE IF EXISTS insert_exec_pspexec;
+DROP PROCEDURE IF EXISTS insert_exec_inner;
+DROP PROCEDURE IF EXISTS insert_exec_outer;
+DROP PROCEDURE IF EXISTS insert_exec_level1;
+DROP PROCEDURE IF EXISTS insert_exec_level2;
+DROP PROCEDURE IF EXISTS insert_exec_level3;
+DROP PROCEDURE IF EXISTS insert_exec_pmultisel;
+DROP PROCEDURE IF EXISTS insert_exec_nestinner;
+DROP PROCEDURE IF EXISTS insert_exec_nestmiddle;
+DROP PROCEDURE IF EXISTS insert_exec_nestouter;
+DROP PROCEDURE IF EXISTS insert_exec_pcust;
+DROP PROCEDURE IF EXISTS insert_exec_pidinsert;
+DROP PROCEDURE IF EXISTS insert_exec_ptemp;
+DROP PROCEDURE IF EXISTS insert_exec_pwithtemp;
+DROP PROCEDURE IF EXISTS insert_exec_pcte;
+DROP PROCEDURE IF EXISTS insert_exec_punion;
+DROP PROCEDURE IF EXISTS insert_exec_pcond;
+DROP PROCEDURE IF EXISTS insert_exec_ploop;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn1;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn2;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn3a;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn3b;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn4;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch1;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch2;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch3;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch4;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch5_inner;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch5_outer;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch6_inner;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch6_outer;
+DROP PROCEDURE IF EXISTS insert_exec_perr2;
+DROP PROCEDURE IF EXISTS insert_exec_plarge;
+DROP PROCEDURE IF EXISTS insert_exec_poutput;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount1;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount2;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount3;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount4;
+GO
+DROP TABLE IF EXISTS insert_exec_t1;
+DROP TABLE IF EXISTS insert_exec_t2;
+DROP TABLE IF EXISTS insert_exec_t3;
+DROP TABLE IF EXISTS insert_exec_t4;
+DROP TABLE IF EXISTS insert_exec_t5;
+DROP TABLE IF EXISTS insert_exec_b1;
+DROP TABLE IF EXISTS insert_exec_types;
+DROP TABLE IF EXISTS insert_exec_nulls;
+DROP TABLE IF EXISTS insert_exec_coerce;
+DROP TABLE IF EXISTS insert_exec_dynamic;
+DROP TABLE IF EXISTS insert_exec_multidyn;
+DROP TABLE IF EXISTS insert_exec_spexec;
+DROP TABLE IF EXISTS insert_exec_nested;
+DROP TABLE IF EXISTS insert_exec_deep;
+DROP TABLE IF EXISTS insert_exec_multisel;
+DROP TABLE IF EXISTS insert_exec_nestmulti;
+DROP TABLE IF EXISTS insert_exec_custdata;
+DROP TABLE IF EXISTS insert_exec_identity;
+DROP TABLE IF EXISTS insert_exec_idinsert;
+DROP TABLE IF EXISTS insert_exec_fromtemp;
+DROP TABLE IF EXISTS insert_exec_cte;
+DROP TABLE IF EXISTS insert_exec_union;
+DROP TABLE IF EXISTS insert_exec_cond;
+DROP TABLE IF EXISTS insert_exec_loop;
+DROP TABLE IF EXISTS insert_exec_txn1;
+DROP TABLE IF EXISTS insert_exec_txn2;
+DROP TABLE IF EXISTS insert_exec_txn3;
+DROP TABLE IF EXISTS insert_exec_txn4;
+DROP TABLE IF EXISTS insert_exec_trycatch1;
+DROP TABLE IF EXISTS insert_exec_trycatch2;
+DROP TABLE IF EXISTS insert_exec_trycatch3;
+DROP TABLE IF EXISTS insert_exec_trycatch4;
+DROP TABLE IF EXISTS insert_exec_trycatch5;
+DROP TABLE IF EXISTS insert_exec_trycatch6;
+DROP TABLE IF EXISTS insert_exec_err2;
+DROP TABLE IF EXISTS insert_exec_large;
+DROP TABLE IF EXISTS insert_exec_output;
+DROP TABLE IF EXISTS insert_exec_trancount1;
+DROP TABLE IF EXISTS insert_exec_trancount2;
+DROP TABLE IF EXISTS insert_exec_trancount3;
+DROP TABLE IF EXISTS insert_exec_trancount4;
+GO
+-- ============================================================================
+-- Category A: Basic INSERT EXEC Scenarios
+-- ============================================================================
+-- A1: Basic INSERT EXEC with Simple Procedure
+CREATE TABLE insert_exec_t1 (id INT, name VARCHAR(100));
+GO
+CREATE PROCEDURE insert_exec_p1 AS
+    SELECT 1, 'test';
+GO
+INSERT INTO insert_exec_t1 EXEC insert_exec_p1;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_t1;
+GO
+~~START~~
+int#!#varchar
+1#!#test
+~~END~~
+
+DROP PROCEDURE insert_exec_p1;
+DROP TABLE insert_exec_t1;
+GO
+-- A2: INSERT EXEC with Multiple Rows
+CREATE TABLE insert_exec_t2 (id INT, value VARCHAR(50));
+GO
+CREATE PROCEDURE insert_exec_p2 AS
+    SELECT 1, 'one'
+    UNION ALL SELECT 2, 'two'
+    UNION ALL SELECT 3, 'three';
+GO
+INSERT INTO insert_exec_t2 EXEC insert_exec_p2;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_t2 ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+3#!#three
+~~END~~
+
+DROP PROCEDURE insert_exec_p2;
+DROP TABLE insert_exec_t2;
+GO
+-- A3: INSERT EXEC with Procedure Parameters
+CREATE TABLE insert_exec_t3 (id INT, computed INT);
+GO
+CREATE PROCEDURE insert_exec_p3 @multiplier INT AS
+    SELECT 1, 1 * @multiplier
+    UNION ALL SELECT 2, 2 * @multiplier
+    UNION ALL SELECT 3, 3 * @multiplier;
+GO
+INSERT INTO insert_exec_t3 EXEC insert_exec_p3 @multiplier = 10;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_t3 ORDER BY id;
+GO
+~~START~~
+int#!#int
+1#!#10
+2#!#20
+3#!#30
+~~END~~
+
+DROP PROCEDURE insert_exec_p3;
+DROP TABLE insert_exec_t3;
+GO
+
+-- A4: INSERT EXEC with Schema-Qualified Procedure
+CREATE TABLE dbo.insert_exec_t4 (id INT);
+GO
+CREATE PROCEDURE dbo.insert_exec_p4 AS
+    SELECT 100;
+GO
+INSERT INTO dbo.insert_exec_t4 EXEC dbo.insert_exec_p4;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM dbo.insert_exec_t4;
+GO
+~~START~~
+int
+100
+~~END~~
+
+DROP PROCEDURE dbo.insert_exec_p4;
+DROP TABLE dbo.insert_exec_t4;
+GO
+-- A5: INSERT EXEC with Empty Result Set
+CREATE TABLE insert_exec_t5 (id INT);
+GO
+CREATE PROCEDURE insert_exec_p5 AS
+    SELECT 1 WHERE 1 = 0;
+GO
+INSERT INTO insert_exec_t5 EXEC insert_exec_p5;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_t5;
+GO
+~~START~~
+int
+0
+~~END~~
+
+DROP PROCEDURE insert_exec_p5;
+DROP TABLE insert_exec_t5;
+GO
+-- ============================================================================
+-- Category B: Column Mapping and Data Types
+-- ============================================================================
+-- B1: INSERT EXEC with Explicit Column List
+CREATE TABLE insert_exec_b1 (a INT, b INT, c INT);
+GO
+CREATE PROCEDURE insert_exec_pb1 AS
+    SELECT 100, 200;
+GO
+INSERT INTO insert_exec_b1 (c, a) EXEC insert_exec_pb1;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_b1;
+GO
+~~START~~
+int#!#int#!#int
+200#!#<NULL>#!#100
+~~END~~
+
+DROP PROCEDURE insert_exec_pb1;
+DROP TABLE insert_exec_b1;
+GO
+-- B2: INSERT EXEC with Various Data Types
+CREATE TABLE insert_exec_types (
+    col_int INT,
+    col_bigint BIGINT,
+    col_decimal DECIMAL(18,2),
+    col_varchar VARCHAR(100),
+    col_nvarchar NVARCHAR(100),
+    col_bit BIT
+);
+GO
+CREATE PROCEDURE insert_exec_ptypes AS
+    SELECT
+        123,
+        9223372036854775807,
+        12345.67,
+        'varchar test',
+        N'nvarchar test',
+        1;
+GO
+INSERT INTO insert_exec_types EXEC insert_exec_ptypes;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_types;
+GO
+~~START~~
+int#!#bigint#!#numeric#!#varchar#!#nvarchar#!#bit
+123#!#9223372036854775807#!#12345.67#!#varchar test#!#nvarchar test#!#1
+~~END~~
+
+DROP PROCEDURE insert_exec_ptypes;
+DROP TABLE insert_exec_types;
+GO
+-- B3: INSERT EXEC with NULL Values
+CREATE TABLE insert_exec_nulls (a INT, b VARCHAR(50), c INT);
+GO
+CREATE PROCEDURE insert_exec_pnulls AS
+    SELECT NULL, 'test', NULL
+    UNION ALL SELECT 1, NULL, 2;
+GO
+INSERT INTO insert_exec_nulls EXEC insert_exec_pnulls;
+GO
+~~ROW COUNT: 2~~
+
+SELECT * FROM insert_exec_nulls ORDER BY a;
+GO
+~~START~~
+int#!#varchar#!#int
+<NULL>#!#test#!#<NULL>
+1#!#<NULL>#!#2
+~~END~~
+
+DROP PROCEDURE insert_exec_pnulls;
+DROP TABLE insert_exec_nulls;
+GO
+-- B4: INSERT EXEC with Type Coercion
+CREATE TABLE insert_exec_coerce (val VARCHAR(10));
+GO
+CREATE PROCEDURE insert_exec_pcoerce AS SELECT 12345;
+GO
+INSERT INTO insert_exec_coerce EXEC insert_exec_pcoerce;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_coerce;
+GO
+~~START~~
+varchar
+12345
+~~END~~
+
+DROP PROCEDURE insert_exec_pcoerce;
+DROP TABLE insert_exec_coerce;
+GO
+
+-- ============================================================================
+-- Category C: Dynamic SQL (BABEL-4306)
+-- ============================================================================
+-- C1: INSERT EXEC with EXEC() inside procedure
+CREATE TABLE insert_exec_dynamic (a INT, b VARCHAR(10));
+GO
+CREATE PROCEDURE insert_exec_pdynamic AS
+    EXEC('SELECT 456, CAST(''def'' AS VARCHAR(10))');
+GO
+INSERT INTO insert_exec_dynamic EXEC insert_exec_pdynamic;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_dynamic;
+GO
+~~START~~
+int#!#varchar
+456#!#def
+~~END~~
+
+DROP PROCEDURE insert_exec_pdynamic;
+DROP TABLE insert_exec_dynamic;
+GO
+-- C2: INSERT EXEC with Multiple Dynamic SQL Statements
+CREATE TABLE insert_exec_multidyn (val INT);
+GO
+CREATE PROCEDURE insert_exec_pmultidyn AS
+    EXEC('SELECT 1');
+    EXEC('SELECT 2');
+    EXEC('SELECT 3');
+GO
+INSERT INTO insert_exec_multidyn EXEC insert_exec_pmultidyn;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_multidyn ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+DROP PROCEDURE insert_exec_pmultidyn;
+DROP TABLE insert_exec_multidyn;
+GO
+-- C3: INSERT EXEC with sp_executesql inside procedure
+CREATE TABLE insert_exec_spexec (a INT);
+GO
+CREATE PROCEDURE insert_exec_pspexec AS
+    EXEC sp_executesql N'SELECT 777';
+GO
+INSERT INTO insert_exec_spexec EXEC insert_exec_pspexec;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_spexec;
+GO
+~~START~~
+int
+777
+~~END~~
+
+DROP PROCEDURE insert_exec_pspexec;
+DROP TABLE insert_exec_spexec;
+GO
+-- ============================================================================
+-- Category D: Nested Procedures
+-- ============================================================================
+-- D1: INSERT EXEC with Nested Procedure Calls
+CREATE TABLE insert_exec_nested (val INT);
+GO
+CREATE PROCEDURE insert_exec_inner AS SELECT 100;
+GO
+CREATE PROCEDURE insert_exec_outer AS EXEC insert_exec_inner;
+GO
+INSERT INTO insert_exec_nested EXEC insert_exec_outer;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_nested;
+GO
+~~START~~
+int
+100
+~~END~~
+
+DROP PROCEDURE insert_exec_outer;
+DROP PROCEDURE insert_exec_inner;
+DROP TABLE insert_exec_nested;
+GO
+-- D2: INSERT EXEC with Deeply Nested Procedures (3 levels)
+CREATE TABLE insert_exec_deep (level_val INT);
+GO
+CREATE PROCEDURE insert_exec_level3 AS SELECT 3;
+GO
+CREATE PROCEDURE insert_exec_level2 AS EXEC insert_exec_level3;
+GO
+CREATE PROCEDURE insert_exec_level1 AS EXEC insert_exec_level2;
+GO
+INSERT INTO insert_exec_deep EXEC insert_exec_level1;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_deep;
+GO
+~~START~~
+int
+3
+~~END~~
+
+DROP PROCEDURE insert_exec_level1;
+DROP PROCEDURE insert_exec_level2;
+DROP PROCEDURE insert_exec_level3;
+DROP TABLE insert_exec_deep;
+GO
+-- D3: INSERT EXEC with Multiple SELECT Statements
+CREATE TABLE insert_exec_multisel (val INT);
+GO
+CREATE PROCEDURE insert_exec_pmultisel AS
+    SELECT 1;
+    SELECT 2;
+    SELECT 3;
+GO
+INSERT INTO insert_exec_multisel EXEC insert_exec_pmultisel;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_multisel ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+DROP PROCEDURE insert_exec_pmultisel;
+DROP TABLE insert_exec_multisel;
+GO
+-- D4: INSERT EXEC with Nested Procedure and Multiple SELECTs
+CREATE TABLE insert_exec_nestmulti (a INT);
+GO
+CREATE PROCEDURE insert_exec_nestinner AS SELECT 10;
+GO
+CREATE PROCEDURE insert_exec_nestmiddle AS EXEC insert_exec_nestinner; SELECT 20;
+GO
+CREATE PROCEDURE insert_exec_nestouter AS EXEC insert_exec_nestmiddle; SELECT 30;
+GO
+INSERT INTO insert_exec_nestmulti EXEC insert_exec_nestouter;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_nestmulti ORDER BY a;
+GO
+~~START~~
+int
+10
+20
+30
+~~END~~
+
+DROP PROCEDURE insert_exec_nestouter;
+DROP PROCEDURE insert_exec_nestmiddle;
+DROP PROCEDURE insert_exec_nestinner;
+DROP TABLE insert_exec_nestmulti;
+GO
+
+-- ============================================================================
+-- Category E: IDENTITY Column Handling (BABEL-4533)
+-- ============================================================================
+-- E1: INSERT EXEC with IDENTITY Column (auto-generated)
+CREATE TABLE insert_exec_custdata (
+    id VARCHAR(100),
+    cust_name VARCHAR(100),
+    city VARCHAR(100)
+);
+GO
+INSERT INTO insert_exec_custdata VALUES
+    (N'GREAL', N'Great Lakes Food Market', N'Eugene');
+GO
+~~ROW COUNT: 1~~
+
+CREATE PROCEDURE insert_exec_pcust AS
+    SELECT id, cust_name, city FROM insert_exec_custdata;
+GO
+CREATE TABLE insert_exec_identity (
+    idcol INT IDENTITY,
+    id VARCHAR(100),
+    cust_name VARCHAR(100),
+    city VARCHAR(100)
+);
+GO
+INSERT INTO insert_exec_identity EXEC insert_exec_pcust;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_identity;
+GO
+~~START~~
+int#!#varchar#!#varchar#!#varchar
+1#!#GREAL#!#Great Lakes Food Market#!#Eugene
+~~END~~
+
+DROP PROCEDURE insert_exec_pcust;
+DROP TABLE insert_exec_custdata;
+DROP TABLE insert_exec_identity;
+GO
+-- E2: INSERT EXEC with IDENTITY_INSERT ON
+CREATE TABLE insert_exec_idinsert (id INT IDENTITY, val VARCHAR(50));
+GO
+CREATE PROCEDURE insert_exec_pidinsert AS
+    SELECT 100, 'explicit id';
+GO
+SET IDENTITY_INSERT insert_exec_idinsert ON;
+INSERT INTO insert_exec_idinsert (id, val) EXEC insert_exec_pidinsert;
+SET IDENTITY_INSERT insert_exec_idinsert OFF;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_idinsert;
+GO
+~~START~~
+int#!#varchar
+100#!#explicit id
+~~END~~
+
+DROP PROCEDURE insert_exec_pidinsert;
+DROP TABLE insert_exec_idinsert;
+GO
+-- ============================================================================
+-- Category F: Temp Tables
+-- ============================================================================
+-- F1: INSERT EXEC into Temp Table
+CREATE TABLE #insert_exec_temp (id INT, name VARCHAR(50));
+GO
+CREATE PROCEDURE insert_exec_ptemp AS
+    SELECT 1, 'one'
+    UNION ALL SELECT 2, 'two';
+GO
+INSERT INTO #insert_exec_temp EXEC insert_exec_ptemp;
+GO
+~~ROW COUNT: 2~~
+
+SELECT * FROM #insert_exec_temp ORDER BY id;
+GO
+~~START~~
+int#!#varchar
+1#!#one
+2#!#two
+~~END~~
+
+DROP PROCEDURE insert_exec_ptemp;
+DROP TABLE #insert_exec_temp;
+GO
+-- F2: INSERT EXEC with Temp Table Inside Procedure
+CREATE TABLE insert_exec_fromtemp (val INT);
+GO
+CREATE PROCEDURE insert_exec_pwithtemp AS
+    CREATE TABLE #inner_temp (x INT);
+    INSERT INTO #inner_temp VALUES (1), (2), (3);
+    SELECT x * 10 FROM #inner_temp;
+GO
+INSERT INTO insert_exec_fromtemp EXEC insert_exec_pwithtemp;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_fromtemp ORDER BY val;
+GO
+~~START~~
+int
+10
+20
+30
+~~END~~
+
+DROP PROCEDURE insert_exec_pwithtemp;
+DROP TABLE insert_exec_fromtemp;
+GO
+-- ============================================================================
+-- Category G: Advanced SQL Constructs
+-- ============================================================================
+-- G1: INSERT EXEC with CTE in Procedure
+CREATE TABLE insert_exec_cte (val INT);
+GO
+CREATE PROCEDURE insert_exec_pcte AS
+    WITH cte AS (
+        SELECT 1 AS n
+        UNION ALL
+        SELECT n + 1 FROM cte WHERE n < 5
+    )
+    SELECT n FROM cte;
+GO
+INSERT INTO insert_exec_cte EXEC insert_exec_pcte;
+GO
+~~ROW COUNT: 5~~
+
+SELECT * FROM insert_exec_cte ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+3
+4
+5
+~~END~~
+
+DROP PROCEDURE insert_exec_pcte;
+DROP TABLE insert_exec_cte;
+GO
+-- G2: INSERT EXEC with UNION ALL
+CREATE TABLE insert_exec_union (a INT);
+GO
+CREATE PROCEDURE insert_exec_punion AS
+    SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3;
+GO
+INSERT INTO insert_exec_union EXEC insert_exec_punion;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_union ORDER BY a;
+GO
+~~START~~
+int
+1
+2
+3
+~~END~~
+
+DROP PROCEDURE insert_exec_punion;
+DROP TABLE insert_exec_union;
+GO
+-- G3: INSERT EXEC with Conditional SELECT
+CREATE TABLE insert_exec_cond (val INT);
+GO
+CREATE PROCEDURE insert_exec_pcond @flag BIT AS
+    IF @flag = 1
+        SELECT 100;
+    ELSE
+        SELECT 200;
+GO
+INSERT INTO insert_exec_cond EXEC insert_exec_pcond @flag = 1;
+INSERT INTO insert_exec_cond EXEC insert_exec_pcond @flag = 0;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_cond ORDER BY val;
+GO
+~~START~~
+int
+100
+200
+~~END~~
+
+DROP PROCEDURE insert_exec_pcond;
+DROP TABLE insert_exec_cond;
+GO
+-- G4: INSERT EXEC with Loop in Procedure
+CREATE TABLE insert_exec_loop (iteration INT, value INT);
+GO
+CREATE PROCEDURE insert_exec_ploop AS
+    DECLARE @i INT = 1;
+    WHILE @i <= 5
+    BEGIN
+        SELECT @i, @i * 10;
+        SET @i = @i + 1;
+    END
+GO
+INSERT INTO insert_exec_loop EXEC insert_exec_ploop;
+GO
+~~ROW COUNT: 5~~
+
+SELECT * FROM insert_exec_loop ORDER BY iteration;
+GO
+~~START~~
+int#!#int
+1#!#10
+2#!#20
+3#!#30
+4#!#40
+5#!#50
+~~END~~
+
+DROP PROCEDURE insert_exec_ploop;
+DROP TABLE insert_exec_loop;
+GO
+
+-- ============================================================================
+-- Category H: Transaction Behavior
+-- ============================================================================
+-- H1: INSERT EXEC with Explicit Transaction - COMMIT
+CREATE TABLE insert_exec_txn1 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn1 AS
+    SELECT 1;
+    SELECT 2;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_txn1 EXEC insert_exec_ptxn1;
+COMMIT;
+GO
+~~ROW COUNT: 2~~
+
+SELECT COUNT(*) AS row_count FROM insert_exec_txn1;
+GO
+~~START~~
+int
+2
+~~END~~
+
+DROP PROCEDURE insert_exec_ptxn1;
+DROP TABLE insert_exec_txn1;
+GO
+-- H2: INSERT EXEC with Explicit Transaction - ROLLBACK
+CREATE TABLE insert_exec_txn2 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn2 AS
+    SELECT 1;
+    SELECT 2;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_txn2 EXEC insert_exec_ptxn2;
+ROLLBACK;
+GO
+~~ROW COUNT: 2~~
+
+SELECT COUNT(*) AS row_count FROM insert_exec_txn2;
+GO
+~~START~~
+int
+0
+~~END~~
+
+DROP PROCEDURE insert_exec_ptxn2;
+DROP TABLE insert_exec_txn2;
+GO
+-- H3: INSERT EXEC with Multiple Procedures in Transaction
+CREATE TABLE insert_exec_txn3 (source VARCHAR(10), val INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn3a AS SELECT 'p1', 1;
+GO
+CREATE PROCEDURE insert_exec_ptxn3b AS SELECT 'p2', 2;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_txn3 EXEC insert_exec_ptxn3a;
+INSERT INTO insert_exec_txn3 EXEC insert_exec_ptxn3b;
+COMMIT;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_txn3 ORDER BY val;
+GO
+~~START~~
+varchar#!#int
+p1#!#1
+p2#!#2
+~~END~~
+
+DROP PROCEDURE insert_exec_ptxn3a;
+DROP PROCEDURE insert_exec_ptxn3b;
+DROP TABLE insert_exec_txn3;
+GO
+-- H4: INSERT EXEC with Transaction Inside Procedure
+CREATE TABLE insert_exec_txn4 (a INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn4 AS
+BEGIN TRY
+    BEGIN TRANSACTION;
+    SELECT 555;
+    COMMIT;
+END TRY
+BEGIN CATCH
+    IF @@TRANCOUNT > 0 ROLLBACK;
+END CATCH
+GO
+INSERT INTO insert_exec_txn4 EXEC insert_exec_ptxn4;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_txn4;
+GO
+~~START~~
+int
+555
+~~END~~
+
+DROP PROCEDURE insert_exec_ptxn4;
+DROP TABLE insert_exec_txn4;
+GO
+-- ============================================================================
+-- Category I: TRY/CATCH Behavior (BABEL-5922)
+-- ============================================================================
+-- I1: TRY/CATCH with Error - Rows Should Be Rolled Back
+CREATE TABLE insert_exec_trycatch1 (id INT, id1 INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch1 AS
+BEGIN TRY
+    SELECT 1, 1;
+    SELECT 1/0;
+END TRY
+BEGIN CATCH
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch1 EXEC insert_exec_ptrycatch1;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: Column name or number of supplied values does not match table definition.)~~
+
+SELECT COUNT(*) AS row_count FROM insert_exec_trycatch1;
+GO
+~~START~~
+int
+0
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrycatch1;
+DROP TABLE insert_exec_trycatch1;
+GO
+-- I2: TRY/CATCH with Successful Execution
+CREATE TABLE insert_exec_trycatch2 (a INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch2 AS
+BEGIN TRY
+    SELECT 100;
+    SELECT 200;
+END TRY
+BEGIN CATCH
+    SELECT -1;
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch2 EXEC insert_exec_ptrycatch2;
+GO
+~~ROW COUNT: 2~~
+
+SELECT * FROM insert_exec_trycatch2 ORDER BY a;
+GO
+~~START~~
+int
+100
+200
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrycatch2;
+DROP TABLE insert_exec_trycatch2;
+GO
+-- I3: TRY/CATCH with RAISERROR (Severity < 11 - continues)
+CREATE TABLE insert_exec_trycatch3 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch3 AS
+BEGIN TRY
+    SELECT 1;
+    RAISERROR('Info message', 10, 1);
+    SELECT 2;
+END TRY
+BEGIN CATCH
+    SELECT -1;
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch3 EXEC insert_exec_ptrycatch3;
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: Info message  Server SQLState: S0001)~~
+
+~~ROW COUNT: 2~~
+
+SELECT * FROM insert_exec_trycatch3 ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrycatch3;
+DROP TABLE insert_exec_trycatch3;
+GO
+-- I4: Nested TRY/CATCH
+CREATE TABLE insert_exec_trycatch4 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch4 AS
+BEGIN TRY
+    SELECT 1;
+    BEGIN TRY
+        SELECT 2;
+        SELECT 1/0;
+    END TRY
+    BEGIN CATCH
+        SELECT 3;
+    END CATCH
+    SELECT 4;
+END TRY
+BEGIN CATCH
+    SELECT -1;
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch4 EXEC insert_exec_ptrycatch4;
+GO
+~~ROW COUNT: 4~~
+
+SELECT * FROM insert_exec_trycatch4 ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+3
+4
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrycatch4;
+DROP TABLE insert_exec_trycatch4;
+GO
+-- I5: Nested Procedure with TRY/CATCH - Success Case
+-- Tests that internal savepoints work correctly when a nested procedure
+-- has TRY-CATCH that catches an error. The inner proc catches the error
+-- and continues, outer proc should see all rows.
+CREATE TABLE insert_exec_trycatch5 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch5_inner AS
+BEGIN TRY
+    SELECT 10;
+    SELECT 1/0;  -- Error caught by inner TRY-CATCH
+    SELECT 20;   -- Not reached
+END TRY
+BEGIN CATCH
+    SELECT 30;   -- Error handler runs
+END CATCH
+SELECT 40;       -- Continues after TRY-CATCH
+GO
+CREATE PROCEDURE insert_exec_ptrycatch5_outer AS
+    SELECT 1;
+    EXEC insert_exec_ptrycatch5_inner;
+    SELECT 2;
+GO
+INSERT INTO insert_exec_trycatch5 EXEC insert_exec_ptrycatch5_outer;
+GO
+~~ROW COUNT: 5~~
+
+SELECT * FROM insert_exec_trycatch5 ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+10
+30
+40
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrycatch5_outer;
+DROP PROCEDURE insert_exec_ptrycatch5_inner;
+DROP TABLE insert_exec_trycatch5;
+GO
+-- I6: Nested Procedure with TRY/CATCH - Failure Case (THROW re-raises)
+-- Tests that when inner proc re-throws an error, it propagates correctly
+-- and all rows are rolled back as expected for INSERT EXEC.
+CREATE TABLE insert_exec_trycatch6 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch6_inner AS
+BEGIN TRY
+    SELECT 10;
+    SELECT 1/0;  -- Error occurs
+END TRY
+BEGIN CATCH
+    SELECT 20;   -- Error handler runs
+    THROW;       -- Re-throw the error
+END CATCH
+GO
+CREATE PROCEDURE insert_exec_ptrycatch6_outer AS
+    SELECT 1;
+    EXEC insert_exec_ptrycatch6_inner;
+    SELECT 2;    -- Not reached due to re-thrown error
+GO
+INSERT INTO insert_exec_trycatch6 EXEC insert_exec_ptrycatch6_outer;
+GO
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+SELECT COUNT(*) AS row_count FROM insert_exec_trycatch6;
+GO
+~~START~~
+int
+0
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrycatch6_outer;
+DROP PROCEDURE insert_exec_ptrycatch6_inner;
+DROP TABLE insert_exec_trycatch6;
+GO
+
+-- ============================================================================
+-- Category J: Error Handling
+-- ============================================================================
+-- J1: INSERT EXEC with Division by Zero (skipped in INSERT EXEC)
+CREATE TABLE insert_exec_err2 (val INT);
+GO
+CREATE PROCEDURE insert_exec_perr2 AS
+    SELECT 1;
+    SELECT 1/0;
+    SELECT 2;
+GO
+INSERT INTO insert_exec_err2 EXEC insert_exec_perr2;
+GO
+~~ERROR (Code: 8134)~~
+
+~~ERROR (Message: division by zero)~~
+
+~~ROW COUNT: 2~~
+
+SELECT * FROM insert_exec_err2 ORDER BY val;
+GO
+~~START~~
+int
+1
+2
+~~END~~
+
+DROP PROCEDURE insert_exec_perr2;
+DROP TABLE insert_exec_err2;
+GO
+-- ============================================================================
+-- Category K: Large Result Sets
+-- ============================================================================
+-- K1: INSERT EXEC with 100 Rows
+CREATE TABLE insert_exec_large (id INT);
+GO
+CREATE PROCEDURE insert_exec_plarge AS
+    DECLARE @i INT = 1;
+    WHILE @i <= 100
+    BEGIN
+        SELECT @i;
+        SET @i = @i + 1;
+    END
+GO
+INSERT INTO insert_exec_large EXEC insert_exec_plarge;
+GO
+~~ROW COUNT: 100~~
+
+SELECT COUNT(*) AS row_count FROM insert_exec_large;
+GO
+~~START~~
+int
+100
+~~END~~
+
+DROP PROCEDURE insert_exec_plarge;
+DROP TABLE insert_exec_large;
+GO
+-- ============================================================================
+-- Category L: OUTPUT Clause (BABEL-5921)
+-- ============================================================================
+-- L1: INSERT EXEC with OUTPUT Clause in Procedure
+CREATE TABLE insert_exec_output (id INT);
+GO
+CREATE PROCEDURE insert_exec_poutput AS
+    DROP TABLE IF EXISTS #temp;
+    CREATE TABLE #temp (id INT);
+    INSERT INTO #temp OUTPUT INSERTED.* VALUES (1);
+GO
+INSERT INTO insert_exec_output EXEC insert_exec_poutput;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_output;
+GO
+~~START~~
+int
+1
+~~END~~
+
+DROP PROCEDURE insert_exec_poutput;
+DROP TABLE insert_exec_output;
+GO
+-- ============================================================================
+-- Category M: Transaction State Visibility (@@TRANCOUNT)
+-- Tests that transaction state is correctly visible inside nested procedures
+-- during INSERT EXEC execution.
+-- ============================================================================
+-- M1: @@TRANCOUNT visibility - no explicit transaction
+CREATE TABLE insert_exec_trancount1 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount1 AS
+    SELECT @@TRANCOUNT;
+GO
+INSERT INTO insert_exec_trancount1 EXEC insert_exec_ptrancount1;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_trancount1;
+GO
+~~START~~
+int
+1
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrancount1;
+DROP TABLE insert_exec_trancount1;
+GO
+-- M2: @@TRANCOUNT visibility - with explicit transaction
+CREATE TABLE insert_exec_trancount2 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount2 AS
+    SELECT @@TRANCOUNT;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_trancount2 EXEC insert_exec_ptrancount2;
+COMMIT;
+GO
+~~ROW COUNT: 1~~
+
+SELECT * FROM insert_exec_trancount2;
+GO
+~~START~~
+int
+1
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrancount2;
+DROP TABLE insert_exec_trancount2;
+GO
+-- M3: @@TRANCOUNT changes inside procedure
+-- Tests that BEGIN TRAN/COMMIT inside the proc correctly updates @@TRANCOUNT
+CREATE TABLE insert_exec_trancount3 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount3 AS
+    SELECT @@TRANCOUNT;
+    BEGIN TRANSACTION;
+    SELECT @@TRANCOUNT;
+    COMMIT;
+    SELECT @@TRANCOUNT;
+GO
+INSERT INTO insert_exec_trancount3 EXEC insert_exec_ptrancount3;
+GO
+~~ROW COUNT: 3~~
+
+SELECT * FROM insert_exec_trancount3 ORDER BY trancount_val;
+GO
+~~START~~
+int
+1
+1
+2
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrancount3;
+DROP TABLE insert_exec_trancount3;
+GO
+-- M4: Multiple nested transactions with @@TRANCOUNT
+CREATE TABLE insert_exec_trancount4 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount4 AS
+    SELECT @@TRANCOUNT;
+    BEGIN TRANSACTION;
+    SELECT @@TRANCOUNT;
+    BEGIN TRANSACTION;
+    SELECT @@TRANCOUNT;
+    COMMIT;
+    SELECT @@TRANCOUNT;
+    COMMIT;
+    SELECT @@TRANCOUNT;
+GO
+INSERT INTO insert_exec_trancount4 EXEC insert_exec_ptrancount4;
+GO
+~~ROW COUNT: 5~~
+
+SELECT * FROM insert_exec_trancount4 ORDER BY trancount_val;
+GO
+~~START~~
+int
+1
+1
+2
+2
+3
+~~END~~
+
+DROP PROCEDURE insert_exec_ptrancount4;
+DROP TABLE insert_exec_trancount4;
+GO
+-- ============================================================================
+-- Cleanup verification
+-- ============================================================================
+SELECT 'All INSERT EXEC tests completed successfully' AS status;
+GO
+~~START~~
+varchar
+All INSERT EXEC tests completed successfully
+~~END~~
+

--- a/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXECUTE.out
@@ -67,7 +67,7 @@ insert into t3 execute sp_multi_selects;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: structure of query does not match function result type)~~
+~~ERROR (Message: Column name or number of supplied values does not match table definition.)~~
 
 select * from t3;
 GO
@@ -456,7 +456,7 @@ insert into t2 execute sp_select_mismatch_with_dml
 go
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: structure of query does not match function result type)~~
+~~ERROR (Message: Column name or number of supplied values does not match table definition.)~~
 
 select * from t1;
 GO
@@ -513,7 +513,7 @@ insert into t2 execute sp_select_mismatch_after_subtran;
 GO
 ~~ERROR (Code: 33557097)~~
 
-~~ERROR (Message: structure of query does not match function result type)~~
+~~ERROR (Message: Column name or number of supplied values does not match table definition.)~~
 
 select * from t1;
 GO
@@ -1067,7 +1067,7 @@ GO
 -- Should fail with nested INSERT ... EXECUTE error
 INSERT INTO t8164 EXEC p8164a;
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -1098,7 +1098,7 @@ GO
 -- Should fail with nested INSERT EXECUTE error
 INSERT INTO t_nest2 EXEC p_outer;
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -1127,7 +1127,7 @@ GO
 -- Should fail with nested INSERT EXECUTE error
 INSERT INTO t_var_nest EXEC p_var_outer;
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -1157,7 +1157,7 @@ GO
 -- Should fail with nested INSERT EXECUTE error
 INSERT INTO t_tran_nest EXEC p_tran_outer;
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -1185,7 +1185,7 @@ GO
 -- Should fail with nested INSERT EXECUTE error
 INSERT INTO t_param_nest EXEC p_param_outer 10;
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -1213,7 +1213,7 @@ GO
 DECLARE @err_temp table(num int);
 INSERT INTO @err_temp EXEC p_err_outer;
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 

--- a/test/JDBC/expected/TestErrorHelperFunctions.out
+++ b/test/JDBC/expected/TestErrorHelperFunctions.out
@@ -210,6 +210,8 @@ XX000#!#The table-valued parameter "%s" must be declared with the READONLY optio
 22008#!#Adding a value to a '%s' column caused an overflow.#!##!#517
 42P01#!#FOR JSON AUTO requires at least one table for generating JSON objects. Use FOR JSON PATH or add a FROM clause with a table name.#!##!#13600
 42P01#!#sub-select and values for json auto are not currently supported.#!##!#13600
+42601#!#nested INSERT ... EXECUTE statements are not allowed#!##!#8164
+0A000#!#INSERT EXEC failed because the stored procedure altered the schema of the target table.#!##!#556
 ~~END~~
 
 

--- a/test/JDBC/expected/TestErrorHelperFunctionsUpgrade-vu-verify.out
+++ b/test/JDBC/expected/TestErrorHelperFunctionsUpgrade-vu-verify.out
@@ -108,6 +108,7 @@ int
 8146
 8152
 8159
+8164
 8179
 9441
 9451
@@ -318,6 +319,8 @@ int
 517
 13600
 13600
+8164
+556
 ~~END~~
 
 
@@ -492,6 +495,8 @@ int
 517
 13600
 13600
+8164
+556
 ~~END~~
 
 
@@ -499,6 +504,6 @@ EXEC TestErrorHelperFunctionsUpgrade_VU_PREPARE_PROC
 GO
 ~~START~~
 int
-167
+169
 ~~END~~
 

--- a/test/JDBC/expected/temp_table_rollback-vu-verify.out
+++ b/test/JDBC/expected/temp_table_rollback-vu-verify.out
@@ -3912,7 +3912,7 @@ GO
 
 INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -4045,7 +4045,7 @@ INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
 GO
 ~~ERROR (Code: 556)~~
 
-~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+~~ERROR (Message: INSERT EXEC failed because the stored procedure altered the schema of the target table.)~~
 
 
 -- Table should still exist with original data since DROP failed

--- a/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_read_uncommitted.out
@@ -4498,7 +4498,7 @@ GO
 
 INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -4631,7 +4631,7 @@ INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
 GO
 ~~ERROR (Code: 556)~~
 
-~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+~~ERROR (Message: INSERT EXEC failed because the stored procedure altered the schema of the target table.)~~
 
 
 -- Table should still exist with original data since DROP failed

--- a/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
+++ b/test/JDBC/expected/temp_table_rollback_isolation_snapshot.out
@@ -4498,7 +4498,7 @@ GO
 
 INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -4631,7 +4631,7 @@ INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
 GO
 ~~ERROR (Code: 556)~~
 
-~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+~~ERROR (Message: INSERT EXEC failed because the stored procedure altered the schema of the target table.)~~
 
 
 -- Table should still exist with original data since DROP failed

--- a/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
+++ b/test/JDBC/expected/temp_table_rollback_xact_abort_on.out
@@ -4499,7 +4499,7 @@ GO
 
 INSERT INTO #insert_exec_nested EXEC p_insert_exec_nested_outer
 GO
-~~ERROR (Code: 33557097)~~
+~~ERROR (Code: 8164)~~
 
 ~~ERROR (Message: nested INSERT ... EXECUTE statements are not allowed)~~
 
@@ -4632,7 +4632,7 @@ INSERT INTO #insert_exec_drop_target EXEC p_insert_exec_drop_table
 GO
 ~~ERROR (Code: 556)~~
 
-~~ERROR (Message: cannot DROP TABLE "#insert_exec_drop_target" because it is being used by active queries in this session)~~
+~~ERROR (Message: INSERT EXEC failed because the stored procedure altered the schema of the target table.)~~
 
 
 -- Table should still exist with original data since DROP failed

--- a/test/JDBC/input/BABEL-INSERT-EXEC.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXEC.sql
@@ -1,0 +1,855 @@
+-- ============================================================================
+-- BABEL-INSERT-EXEC: Comprehensive test for INSERT INTO ... EXEC functionality
+-- Tests the Temp Table + Query Rewriting approach for INSERT EXEC
+-- ============================================================================
+-- ============================================================================
+-- Cleanup any leftover objects from previous failed runs
+-- ============================================================================
+DROP PROCEDURE IF EXISTS insert_exec_p1;
+DROP PROCEDURE IF EXISTS insert_exec_p2;
+DROP PROCEDURE IF EXISTS insert_exec_p3;
+DROP PROCEDURE IF EXISTS insert_exec_p4;
+DROP PROCEDURE IF EXISTS insert_exec_p5;
+DROP PROCEDURE IF EXISTS insert_exec_pb1;
+DROP PROCEDURE IF EXISTS insert_exec_ptypes;
+DROP PROCEDURE IF EXISTS insert_exec_pnulls;
+DROP PROCEDURE IF EXISTS insert_exec_pcoerce;
+DROP PROCEDURE IF EXISTS insert_exec_pdynamic;
+DROP PROCEDURE IF EXISTS insert_exec_pmultidyn;
+DROP PROCEDURE IF EXISTS insert_exec_pspexec;
+DROP PROCEDURE IF EXISTS insert_exec_inner;
+DROP PROCEDURE IF EXISTS insert_exec_outer;
+DROP PROCEDURE IF EXISTS insert_exec_level1;
+DROP PROCEDURE IF EXISTS insert_exec_level2;
+DROP PROCEDURE IF EXISTS insert_exec_level3;
+DROP PROCEDURE IF EXISTS insert_exec_pmultisel;
+DROP PROCEDURE IF EXISTS insert_exec_nestinner;
+DROP PROCEDURE IF EXISTS insert_exec_nestmiddle;
+DROP PROCEDURE IF EXISTS insert_exec_nestouter;
+DROP PROCEDURE IF EXISTS insert_exec_pcust;
+DROP PROCEDURE IF EXISTS insert_exec_pidinsert;
+DROP PROCEDURE IF EXISTS insert_exec_ptemp;
+DROP PROCEDURE IF EXISTS insert_exec_pwithtemp;
+DROP PROCEDURE IF EXISTS insert_exec_pcte;
+DROP PROCEDURE IF EXISTS insert_exec_punion;
+DROP PROCEDURE IF EXISTS insert_exec_pcond;
+DROP PROCEDURE IF EXISTS insert_exec_ploop;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn1;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn2;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn3a;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn3b;
+DROP PROCEDURE IF EXISTS insert_exec_ptxn4;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch1;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch2;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch3;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch4;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch5_inner;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch5_outer;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch6_inner;
+DROP PROCEDURE IF EXISTS insert_exec_ptrycatch6_outer;
+DROP PROCEDURE IF EXISTS insert_exec_perr2;
+DROP PROCEDURE IF EXISTS insert_exec_plarge;
+DROP PROCEDURE IF EXISTS insert_exec_poutput;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount1;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount2;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount3;
+DROP PROCEDURE IF EXISTS insert_exec_ptrancount4;
+GO
+DROP TABLE IF EXISTS insert_exec_t1;
+DROP TABLE IF EXISTS insert_exec_t2;
+DROP TABLE IF EXISTS insert_exec_t3;
+DROP TABLE IF EXISTS insert_exec_t4;
+DROP TABLE IF EXISTS insert_exec_t5;
+DROP TABLE IF EXISTS insert_exec_b1;
+DROP TABLE IF EXISTS insert_exec_types;
+DROP TABLE IF EXISTS insert_exec_nulls;
+DROP TABLE IF EXISTS insert_exec_coerce;
+DROP TABLE IF EXISTS insert_exec_dynamic;
+DROP TABLE IF EXISTS insert_exec_multidyn;
+DROP TABLE IF EXISTS insert_exec_spexec;
+DROP TABLE IF EXISTS insert_exec_nested;
+DROP TABLE IF EXISTS insert_exec_deep;
+DROP TABLE IF EXISTS insert_exec_multisel;
+DROP TABLE IF EXISTS insert_exec_nestmulti;
+DROP TABLE IF EXISTS insert_exec_custdata;
+DROP TABLE IF EXISTS insert_exec_identity;
+DROP TABLE IF EXISTS insert_exec_idinsert;
+DROP TABLE IF EXISTS insert_exec_fromtemp;
+DROP TABLE IF EXISTS insert_exec_cte;
+DROP TABLE IF EXISTS insert_exec_union;
+DROP TABLE IF EXISTS insert_exec_cond;
+DROP TABLE IF EXISTS insert_exec_loop;
+DROP TABLE IF EXISTS insert_exec_txn1;
+DROP TABLE IF EXISTS insert_exec_txn2;
+DROP TABLE IF EXISTS insert_exec_txn3;
+DROP TABLE IF EXISTS insert_exec_txn4;
+DROP TABLE IF EXISTS insert_exec_trycatch1;
+DROP TABLE IF EXISTS insert_exec_trycatch2;
+DROP TABLE IF EXISTS insert_exec_trycatch3;
+DROP TABLE IF EXISTS insert_exec_trycatch4;
+DROP TABLE IF EXISTS insert_exec_trycatch5;
+DROP TABLE IF EXISTS insert_exec_trycatch6;
+DROP TABLE IF EXISTS insert_exec_err2;
+DROP TABLE IF EXISTS insert_exec_large;
+DROP TABLE IF EXISTS insert_exec_output;
+DROP TABLE IF EXISTS insert_exec_trancount1;
+DROP TABLE IF EXISTS insert_exec_trancount2;
+DROP TABLE IF EXISTS insert_exec_trancount3;
+DROP TABLE IF EXISTS insert_exec_trancount4;
+GO
+-- ============================================================================
+-- Category A: Basic INSERT EXEC Scenarios
+-- ============================================================================
+-- A1: Basic INSERT EXEC with Simple Procedure
+CREATE TABLE insert_exec_t1 (id INT, name VARCHAR(100));
+GO
+CREATE PROCEDURE insert_exec_p1 AS
+    SELECT 1, 'test';
+GO
+INSERT INTO insert_exec_t1 EXEC insert_exec_p1;
+GO
+SELECT * FROM insert_exec_t1;
+GO
+DROP PROCEDURE insert_exec_p1;
+DROP TABLE insert_exec_t1;
+GO
+-- A2: INSERT EXEC with Multiple Rows
+CREATE TABLE insert_exec_t2 (id INT, value VARCHAR(50));
+GO
+CREATE PROCEDURE insert_exec_p2 AS
+    SELECT 1, 'one'
+    UNION ALL SELECT 2, 'two'
+    UNION ALL SELECT 3, 'three';
+GO
+INSERT INTO insert_exec_t2 EXEC insert_exec_p2;
+GO
+SELECT * FROM insert_exec_t2 ORDER BY id;
+GO
+DROP PROCEDURE insert_exec_p2;
+DROP TABLE insert_exec_t2;
+GO
+-- A3: INSERT EXEC with Procedure Parameters
+CREATE TABLE insert_exec_t3 (id INT, computed INT);
+GO
+CREATE PROCEDURE insert_exec_p3 @multiplier INT AS
+    SELECT 1, 1 * @multiplier
+    UNION ALL SELECT 2, 2 * @multiplier
+    UNION ALL SELECT 3, 3 * @multiplier;
+GO
+INSERT INTO insert_exec_t3 EXEC insert_exec_p3 @multiplier = 10;
+GO
+SELECT * FROM insert_exec_t3 ORDER BY id;
+GO
+DROP PROCEDURE insert_exec_p3;
+DROP TABLE insert_exec_t3;
+GO
+
+-- A4: INSERT EXEC with Schema-Qualified Procedure
+CREATE TABLE dbo.insert_exec_t4 (id INT);
+GO
+CREATE PROCEDURE dbo.insert_exec_p4 AS
+    SELECT 100;
+GO
+INSERT INTO dbo.insert_exec_t4 EXEC dbo.insert_exec_p4;
+GO
+SELECT * FROM dbo.insert_exec_t4;
+GO
+DROP PROCEDURE dbo.insert_exec_p4;
+DROP TABLE dbo.insert_exec_t4;
+GO
+-- A5: INSERT EXEC with Empty Result Set
+CREATE TABLE insert_exec_t5 (id INT);
+GO
+CREATE PROCEDURE insert_exec_p5 AS
+    SELECT 1 WHERE 1 = 0;
+GO
+INSERT INTO insert_exec_t5 EXEC insert_exec_p5;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_t5;
+GO
+DROP PROCEDURE insert_exec_p5;
+DROP TABLE insert_exec_t5;
+GO
+-- ============================================================================
+-- Category B: Column Mapping and Data Types
+-- ============================================================================
+-- B1: INSERT EXEC with Explicit Column List
+CREATE TABLE insert_exec_b1 (a INT, b INT, c INT);
+GO
+CREATE PROCEDURE insert_exec_pb1 AS
+    SELECT 100, 200;
+GO
+INSERT INTO insert_exec_b1 (c, a) EXEC insert_exec_pb1;
+GO
+SELECT * FROM insert_exec_b1;
+GO
+DROP PROCEDURE insert_exec_pb1;
+DROP TABLE insert_exec_b1;
+GO
+-- B2: INSERT EXEC with Various Data Types
+CREATE TABLE insert_exec_types (
+    col_int INT,
+    col_bigint BIGINT,
+    col_decimal DECIMAL(18,2),
+    col_varchar VARCHAR(100),
+    col_nvarchar NVARCHAR(100),
+    col_bit BIT
+);
+GO
+CREATE PROCEDURE insert_exec_ptypes AS
+    SELECT
+        123,
+        9223372036854775807,
+        12345.67,
+        'varchar test',
+        N'nvarchar test',
+        1;
+GO
+INSERT INTO insert_exec_types EXEC insert_exec_ptypes;
+GO
+SELECT * FROM insert_exec_types;
+GO
+DROP PROCEDURE insert_exec_ptypes;
+DROP TABLE insert_exec_types;
+GO
+-- B3: INSERT EXEC with NULL Values
+CREATE TABLE insert_exec_nulls (a INT, b VARCHAR(50), c INT);
+GO
+CREATE PROCEDURE insert_exec_pnulls AS
+    SELECT NULL, 'test', NULL
+    UNION ALL SELECT 1, NULL, 2;
+GO
+INSERT INTO insert_exec_nulls EXEC insert_exec_pnulls;
+GO
+SELECT * FROM insert_exec_nulls ORDER BY a;
+GO
+DROP PROCEDURE insert_exec_pnulls;
+DROP TABLE insert_exec_nulls;
+GO
+-- B4: INSERT EXEC with Type Coercion
+CREATE TABLE insert_exec_coerce (val VARCHAR(10));
+GO
+CREATE PROCEDURE insert_exec_pcoerce AS SELECT 12345;
+GO
+INSERT INTO insert_exec_coerce EXEC insert_exec_pcoerce;
+GO
+SELECT * FROM insert_exec_coerce;
+GO
+DROP PROCEDURE insert_exec_pcoerce;
+DROP TABLE insert_exec_coerce;
+GO
+
+-- ============================================================================
+-- Category C: Dynamic SQL (BABEL-4306)
+-- ============================================================================
+-- C1: INSERT EXEC with EXEC() inside procedure
+CREATE TABLE insert_exec_dynamic (a INT, b VARCHAR(10));
+GO
+CREATE PROCEDURE insert_exec_pdynamic AS
+    EXEC('SELECT 456, CAST(''def'' AS VARCHAR(10))');
+GO
+INSERT INTO insert_exec_dynamic EXEC insert_exec_pdynamic;
+GO
+SELECT * FROM insert_exec_dynamic;
+GO
+DROP PROCEDURE insert_exec_pdynamic;
+DROP TABLE insert_exec_dynamic;
+GO
+-- C2: INSERT EXEC with Multiple Dynamic SQL Statements
+CREATE TABLE insert_exec_multidyn (val INT);
+GO
+CREATE PROCEDURE insert_exec_pmultidyn AS
+    EXEC('SELECT 1');
+    EXEC('SELECT 2');
+    EXEC('SELECT 3');
+GO
+INSERT INTO insert_exec_multidyn EXEC insert_exec_pmultidyn;
+GO
+SELECT * FROM insert_exec_multidyn ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_pmultidyn;
+DROP TABLE insert_exec_multidyn;
+GO
+-- C3: INSERT EXEC with sp_executesql inside procedure
+CREATE TABLE insert_exec_spexec (a INT);
+GO
+CREATE PROCEDURE insert_exec_pspexec AS
+    EXEC sp_executesql N'SELECT 777';
+GO
+INSERT INTO insert_exec_spexec EXEC insert_exec_pspexec;
+GO
+SELECT * FROM insert_exec_spexec;
+GO
+DROP PROCEDURE insert_exec_pspexec;
+DROP TABLE insert_exec_spexec;
+GO
+-- ============================================================================
+-- Category D: Nested Procedures
+-- ============================================================================
+-- D1: INSERT EXEC with Nested Procedure Calls
+CREATE TABLE insert_exec_nested (val INT);
+GO
+CREATE PROCEDURE insert_exec_inner AS SELECT 100;
+GO
+CREATE PROCEDURE insert_exec_outer AS EXEC insert_exec_inner;
+GO
+INSERT INTO insert_exec_nested EXEC insert_exec_outer;
+GO
+SELECT * FROM insert_exec_nested;
+GO
+DROP PROCEDURE insert_exec_outer;
+DROP PROCEDURE insert_exec_inner;
+DROP TABLE insert_exec_nested;
+GO
+-- D2: INSERT EXEC with Deeply Nested Procedures (3 levels)
+CREATE TABLE insert_exec_deep (level_val INT);
+GO
+CREATE PROCEDURE insert_exec_level3 AS SELECT 3;
+GO
+CREATE PROCEDURE insert_exec_level2 AS EXEC insert_exec_level3;
+GO
+CREATE PROCEDURE insert_exec_level1 AS EXEC insert_exec_level2;
+GO
+INSERT INTO insert_exec_deep EXEC insert_exec_level1;
+GO
+SELECT * FROM insert_exec_deep;
+GO
+DROP PROCEDURE insert_exec_level1;
+DROP PROCEDURE insert_exec_level2;
+DROP PROCEDURE insert_exec_level3;
+DROP TABLE insert_exec_deep;
+GO
+-- D3: INSERT EXEC with Multiple SELECT Statements
+CREATE TABLE insert_exec_multisel (val INT);
+GO
+CREATE PROCEDURE insert_exec_pmultisel AS
+    SELECT 1;
+    SELECT 2;
+    SELECT 3;
+GO
+INSERT INTO insert_exec_multisel EXEC insert_exec_pmultisel;
+GO
+SELECT * FROM insert_exec_multisel ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_pmultisel;
+DROP TABLE insert_exec_multisel;
+GO
+-- D4: INSERT EXEC with Nested Procedure and Multiple SELECTs
+CREATE TABLE insert_exec_nestmulti (a INT);
+GO
+CREATE PROCEDURE insert_exec_nestinner AS SELECT 10;
+GO
+CREATE PROCEDURE insert_exec_nestmiddle AS EXEC insert_exec_nestinner; SELECT 20;
+GO
+CREATE PROCEDURE insert_exec_nestouter AS EXEC insert_exec_nestmiddle; SELECT 30;
+GO
+INSERT INTO insert_exec_nestmulti EXEC insert_exec_nestouter;
+GO
+SELECT * FROM insert_exec_nestmulti ORDER BY a;
+GO
+DROP PROCEDURE insert_exec_nestouter;
+DROP PROCEDURE insert_exec_nestmiddle;
+DROP PROCEDURE insert_exec_nestinner;
+DROP TABLE insert_exec_nestmulti;
+GO
+
+-- ============================================================================
+-- Category E: IDENTITY Column Handling (BABEL-4533)
+-- ============================================================================
+-- E1: INSERT EXEC with IDENTITY Column (auto-generated)
+CREATE TABLE insert_exec_custdata (
+    id VARCHAR(100),
+    cust_name VARCHAR(100),
+    city VARCHAR(100)
+);
+GO
+INSERT INTO insert_exec_custdata VALUES
+    (N'GREAL', N'Great Lakes Food Market', N'Eugene');
+GO
+CREATE PROCEDURE insert_exec_pcust AS
+    SELECT id, cust_name, city FROM insert_exec_custdata;
+GO
+CREATE TABLE insert_exec_identity (
+    idcol INT IDENTITY,
+    id VARCHAR(100),
+    cust_name VARCHAR(100),
+    city VARCHAR(100)
+);
+GO
+INSERT INTO insert_exec_identity EXEC insert_exec_pcust;
+GO
+SELECT * FROM insert_exec_identity;
+GO
+DROP PROCEDURE insert_exec_pcust;
+DROP TABLE insert_exec_custdata;
+DROP TABLE insert_exec_identity;
+GO
+-- E2: INSERT EXEC with IDENTITY_INSERT ON
+CREATE TABLE insert_exec_idinsert (id INT IDENTITY, val VARCHAR(50));
+GO
+CREATE PROCEDURE insert_exec_pidinsert AS
+    SELECT 100, 'explicit id';
+GO
+SET IDENTITY_INSERT insert_exec_idinsert ON;
+INSERT INTO insert_exec_idinsert (id, val) EXEC insert_exec_pidinsert;
+SET IDENTITY_INSERT insert_exec_idinsert OFF;
+GO
+SELECT * FROM insert_exec_idinsert;
+GO
+DROP PROCEDURE insert_exec_pidinsert;
+DROP TABLE insert_exec_idinsert;
+GO
+-- ============================================================================
+-- Category F: Temp Tables
+-- ============================================================================
+-- F1: INSERT EXEC into Temp Table
+CREATE TABLE #insert_exec_temp (id INT, name VARCHAR(50));
+GO
+CREATE PROCEDURE insert_exec_ptemp AS
+    SELECT 1, 'one'
+    UNION ALL SELECT 2, 'two';
+GO
+INSERT INTO #insert_exec_temp EXEC insert_exec_ptemp;
+GO
+SELECT * FROM #insert_exec_temp ORDER BY id;
+GO
+DROP PROCEDURE insert_exec_ptemp;
+DROP TABLE #insert_exec_temp;
+GO
+-- F2: INSERT EXEC with Temp Table Inside Procedure
+CREATE TABLE insert_exec_fromtemp (val INT);
+GO
+CREATE PROCEDURE insert_exec_pwithtemp AS
+    CREATE TABLE #inner_temp (x INT);
+    INSERT INTO #inner_temp VALUES (1), (2), (3);
+    SELECT x * 10 FROM #inner_temp;
+GO
+INSERT INTO insert_exec_fromtemp EXEC insert_exec_pwithtemp;
+GO
+SELECT * FROM insert_exec_fromtemp ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_pwithtemp;
+DROP TABLE insert_exec_fromtemp;
+GO
+-- ============================================================================
+-- Category G: Advanced SQL Constructs
+-- ============================================================================
+-- G1: INSERT EXEC with CTE in Procedure
+CREATE TABLE insert_exec_cte (val INT);
+GO
+CREATE PROCEDURE insert_exec_pcte AS
+    WITH cte AS (
+        SELECT 1 AS n
+        UNION ALL
+        SELECT n + 1 FROM cte WHERE n < 5
+    )
+    SELECT n FROM cte;
+GO
+INSERT INTO insert_exec_cte EXEC insert_exec_pcte;
+GO
+SELECT * FROM insert_exec_cte ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_pcte;
+DROP TABLE insert_exec_cte;
+GO
+-- G2: INSERT EXEC with UNION ALL
+CREATE TABLE insert_exec_union (a INT);
+GO
+CREATE PROCEDURE insert_exec_punion AS
+    SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3;
+GO
+INSERT INTO insert_exec_union EXEC insert_exec_punion;
+GO
+SELECT * FROM insert_exec_union ORDER BY a;
+GO
+DROP PROCEDURE insert_exec_punion;
+DROP TABLE insert_exec_union;
+GO
+-- G3: INSERT EXEC with Conditional SELECT
+CREATE TABLE insert_exec_cond (val INT);
+GO
+CREATE PROCEDURE insert_exec_pcond @flag BIT AS
+    IF @flag = 1
+        SELECT 100;
+    ELSE
+        SELECT 200;
+GO
+INSERT INTO insert_exec_cond EXEC insert_exec_pcond @flag = 1;
+INSERT INTO insert_exec_cond EXEC insert_exec_pcond @flag = 0;
+GO
+SELECT * FROM insert_exec_cond ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_pcond;
+DROP TABLE insert_exec_cond;
+GO
+-- G4: INSERT EXEC with Loop in Procedure
+CREATE TABLE insert_exec_loop (iteration INT, value INT);
+GO
+CREATE PROCEDURE insert_exec_ploop AS
+    DECLARE @i INT = 1;
+    WHILE @i <= 5
+    BEGIN
+        SELECT @i, @i * 10;
+        SET @i = @i + 1;
+    END
+GO
+INSERT INTO insert_exec_loop EXEC insert_exec_ploop;
+GO
+SELECT * FROM insert_exec_loop ORDER BY iteration;
+GO
+DROP PROCEDURE insert_exec_ploop;
+DROP TABLE insert_exec_loop;
+GO
+
+-- ============================================================================
+-- Category H: Transaction Behavior
+-- ============================================================================
+-- H1: INSERT EXEC with Explicit Transaction - COMMIT
+CREATE TABLE insert_exec_txn1 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn1 AS
+    SELECT 1;
+    SELECT 2;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_txn1 EXEC insert_exec_ptxn1;
+COMMIT;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_txn1;
+GO
+DROP PROCEDURE insert_exec_ptxn1;
+DROP TABLE insert_exec_txn1;
+GO
+-- H2: INSERT EXEC with Explicit Transaction - ROLLBACK
+CREATE TABLE insert_exec_txn2 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn2 AS
+    SELECT 1;
+    SELECT 2;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_txn2 EXEC insert_exec_ptxn2;
+ROLLBACK;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_txn2;
+GO
+DROP PROCEDURE insert_exec_ptxn2;
+DROP TABLE insert_exec_txn2;
+GO
+-- H3: INSERT EXEC with Multiple Procedures in Transaction
+CREATE TABLE insert_exec_txn3 (source VARCHAR(10), val INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn3a AS SELECT 'p1', 1;
+GO
+CREATE PROCEDURE insert_exec_ptxn3b AS SELECT 'p2', 2;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_txn3 EXEC insert_exec_ptxn3a;
+INSERT INTO insert_exec_txn3 EXEC insert_exec_ptxn3b;
+COMMIT;
+GO
+SELECT * FROM insert_exec_txn3 ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_ptxn3a;
+DROP PROCEDURE insert_exec_ptxn3b;
+DROP TABLE insert_exec_txn3;
+GO
+-- H4: INSERT EXEC with Transaction Inside Procedure
+CREATE TABLE insert_exec_txn4 (a INT);
+GO
+CREATE PROCEDURE insert_exec_ptxn4 AS
+BEGIN TRY
+    BEGIN TRANSACTION;
+    SELECT 555;
+    COMMIT;
+END TRY
+BEGIN CATCH
+    IF @@TRANCOUNT > 0 ROLLBACK;
+END CATCH
+GO
+INSERT INTO insert_exec_txn4 EXEC insert_exec_ptxn4;
+GO
+SELECT * FROM insert_exec_txn4;
+GO
+DROP PROCEDURE insert_exec_ptxn4;
+DROP TABLE insert_exec_txn4;
+GO
+-- ============================================================================
+-- Category I: TRY/CATCH Behavior (BABEL-5922)
+-- ============================================================================
+-- I1: TRY/CATCH with Error - Rows Should Be Rolled Back
+CREATE TABLE insert_exec_trycatch1 (id INT, id1 INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch1 AS
+BEGIN TRY
+    SELECT 1, 1;
+    SELECT 1/0;
+END TRY
+BEGIN CATCH
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch1 EXEC insert_exec_ptrycatch1;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_trycatch1;
+GO
+DROP PROCEDURE insert_exec_ptrycatch1;
+DROP TABLE insert_exec_trycatch1;
+GO
+-- I2: TRY/CATCH with Successful Execution
+CREATE TABLE insert_exec_trycatch2 (a INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch2 AS
+BEGIN TRY
+    SELECT 100;
+    SELECT 200;
+END TRY
+BEGIN CATCH
+    SELECT -1;
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch2 EXEC insert_exec_ptrycatch2;
+GO
+SELECT * FROM insert_exec_trycatch2 ORDER BY a;
+GO
+DROP PROCEDURE insert_exec_ptrycatch2;
+DROP TABLE insert_exec_trycatch2;
+GO
+-- I3: TRY/CATCH with RAISERROR (Severity < 11 - continues)
+CREATE TABLE insert_exec_trycatch3 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch3 AS
+BEGIN TRY
+    SELECT 1;
+    RAISERROR('Info message', 10, 1);
+    SELECT 2;
+END TRY
+BEGIN CATCH
+    SELECT -1;
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch3 EXEC insert_exec_ptrycatch3;
+GO
+SELECT * FROM insert_exec_trycatch3 ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_ptrycatch3;
+DROP TABLE insert_exec_trycatch3;
+GO
+-- I4: Nested TRY/CATCH
+CREATE TABLE insert_exec_trycatch4 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch4 AS
+BEGIN TRY
+    SELECT 1;
+    BEGIN TRY
+        SELECT 2;
+        SELECT 1/0;
+    END TRY
+    BEGIN CATCH
+        SELECT 3;
+    END CATCH
+    SELECT 4;
+END TRY
+BEGIN CATCH
+    SELECT -1;
+END CATCH
+GO
+INSERT INTO insert_exec_trycatch4 EXEC insert_exec_ptrycatch4;
+GO
+SELECT * FROM insert_exec_trycatch4 ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_ptrycatch4;
+DROP TABLE insert_exec_trycatch4;
+GO
+-- I5: Nested Procedure with TRY/CATCH - Success Case
+-- Tests that internal savepoints work correctly when a nested procedure
+-- has TRY-CATCH that catches an error. The inner proc catches the error
+-- and continues, outer proc should see all rows.
+CREATE TABLE insert_exec_trycatch5 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch5_inner AS
+BEGIN TRY
+    SELECT 10;
+    SELECT 1/0;  -- Error caught by inner TRY-CATCH
+    SELECT 20;   -- Not reached
+END TRY
+BEGIN CATCH
+    SELECT 30;   -- Error handler runs
+END CATCH
+SELECT 40;       -- Continues after TRY-CATCH
+GO
+CREATE PROCEDURE insert_exec_ptrycatch5_outer AS
+    SELECT 1;
+    EXEC insert_exec_ptrycatch5_inner;
+    SELECT 2;
+GO
+INSERT INTO insert_exec_trycatch5 EXEC insert_exec_ptrycatch5_outer;
+GO
+SELECT * FROM insert_exec_trycatch5 ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_ptrycatch5_outer;
+DROP PROCEDURE insert_exec_ptrycatch5_inner;
+DROP TABLE insert_exec_trycatch5;
+GO
+-- I6: Nested Procedure with TRY/CATCH - Failure Case (THROW re-raises)
+-- Tests that when inner proc re-throws an error, it propagates correctly
+-- and all rows are rolled back as expected for INSERT EXEC.
+CREATE TABLE insert_exec_trycatch6 (val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrycatch6_inner AS
+BEGIN TRY
+    SELECT 10;
+    SELECT 1/0;  -- Error occurs
+END TRY
+BEGIN CATCH
+    SELECT 20;   -- Error handler runs
+    THROW;       -- Re-throw the error
+END CATCH
+GO
+CREATE PROCEDURE insert_exec_ptrycatch6_outer AS
+    SELECT 1;
+    EXEC insert_exec_ptrycatch6_inner;
+    SELECT 2;    -- Not reached due to re-thrown error
+GO
+INSERT INTO insert_exec_trycatch6 EXEC insert_exec_ptrycatch6_outer;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_trycatch6;
+GO
+DROP PROCEDURE insert_exec_ptrycatch6_outer;
+DROP PROCEDURE insert_exec_ptrycatch6_inner;
+DROP TABLE insert_exec_trycatch6;
+GO
+
+-- ============================================================================
+-- Category J: Error Handling
+-- ============================================================================
+-- J1: INSERT EXEC with Division by Zero (skipped in INSERT EXEC)
+CREATE TABLE insert_exec_err2 (val INT);
+GO
+CREATE PROCEDURE insert_exec_perr2 AS
+    SELECT 1;
+    SELECT 1/0;
+    SELECT 2;
+GO
+INSERT INTO insert_exec_err2 EXEC insert_exec_perr2;
+GO
+SELECT * FROM insert_exec_err2 ORDER BY val;
+GO
+DROP PROCEDURE insert_exec_perr2;
+DROP TABLE insert_exec_err2;
+GO
+-- ============================================================================
+-- Category K: Large Result Sets
+-- ============================================================================
+-- K1: INSERT EXEC with 100 Rows
+CREATE TABLE insert_exec_large (id INT);
+GO
+CREATE PROCEDURE insert_exec_plarge AS
+    DECLARE @i INT = 1;
+    WHILE @i <= 100
+    BEGIN
+        SELECT @i;
+        SET @i = @i + 1;
+    END
+GO
+INSERT INTO insert_exec_large EXEC insert_exec_plarge;
+GO
+SELECT COUNT(*) AS row_count FROM insert_exec_large;
+GO
+DROP PROCEDURE insert_exec_plarge;
+DROP TABLE insert_exec_large;
+GO
+-- ============================================================================
+-- Category L: OUTPUT Clause (BABEL-5921)
+-- ============================================================================
+-- L1: INSERT EXEC with OUTPUT Clause in Procedure
+CREATE TABLE insert_exec_output (id INT);
+GO
+CREATE PROCEDURE insert_exec_poutput AS
+    DROP TABLE IF EXISTS #temp;
+    CREATE TABLE #temp (id INT);
+    INSERT INTO #temp OUTPUT INSERTED.* VALUES (1);
+GO
+INSERT INTO insert_exec_output EXEC insert_exec_poutput;
+GO
+SELECT * FROM insert_exec_output;
+GO
+DROP PROCEDURE insert_exec_poutput;
+DROP TABLE insert_exec_output;
+GO
+-- ============================================================================
+-- Category M: Transaction State Visibility (@@TRANCOUNT)
+-- Tests that transaction state is correctly visible inside nested procedures
+-- during INSERT EXEC execution.
+-- ============================================================================
+-- M1: @@TRANCOUNT visibility - no explicit transaction
+CREATE TABLE insert_exec_trancount1 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount1 AS
+    SELECT @@TRANCOUNT;
+GO
+INSERT INTO insert_exec_trancount1 EXEC insert_exec_ptrancount1;
+GO
+SELECT * FROM insert_exec_trancount1;
+GO
+DROP PROCEDURE insert_exec_ptrancount1;
+DROP TABLE insert_exec_trancount1;
+GO
+-- M2: @@TRANCOUNT visibility - with explicit transaction
+CREATE TABLE insert_exec_trancount2 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount2 AS
+    SELECT @@TRANCOUNT;
+GO
+BEGIN TRANSACTION;
+INSERT INTO insert_exec_trancount2 EXEC insert_exec_ptrancount2;
+COMMIT;
+GO
+SELECT * FROM insert_exec_trancount2;
+GO
+DROP PROCEDURE insert_exec_ptrancount2;
+DROP TABLE insert_exec_trancount2;
+GO
+-- M3: @@TRANCOUNT changes inside procedure
+-- Tests that BEGIN TRAN/COMMIT inside the proc correctly updates @@TRANCOUNT
+CREATE TABLE insert_exec_trancount3 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount3 AS
+    SELECT @@TRANCOUNT;
+    BEGIN TRANSACTION;
+    SELECT @@TRANCOUNT;
+    COMMIT;
+    SELECT @@TRANCOUNT;
+GO
+INSERT INTO insert_exec_trancount3 EXEC insert_exec_ptrancount3;
+GO
+SELECT * FROM insert_exec_trancount3 ORDER BY trancount_val;
+GO
+DROP PROCEDURE insert_exec_ptrancount3;
+DROP TABLE insert_exec_trancount3;
+GO
+-- M4: Multiple nested transactions with @@TRANCOUNT
+CREATE TABLE insert_exec_trancount4 (trancount_val INT);
+GO
+CREATE PROCEDURE insert_exec_ptrancount4 AS
+    SELECT @@TRANCOUNT;
+    BEGIN TRANSACTION;
+    SELECT @@TRANCOUNT;
+    BEGIN TRANSACTION;
+    SELECT @@TRANCOUNT;
+    COMMIT;
+    SELECT @@TRANCOUNT;
+    COMMIT;
+    SELECT @@TRANCOUNT;
+GO
+INSERT INTO insert_exec_trancount4 EXEC insert_exec_ptrancount4;
+GO
+SELECT * FROM insert_exec_trancount4 ORDER BY trancount_val;
+GO
+DROP PROCEDURE insert_exec_ptrancount4;
+DROP TABLE insert_exec_trancount4;
+GO
+-- ============================================================================
+-- Cleanup verification
+-- ============================================================================
+SELECT 'All INSERT EXEC tests completed successfully' AS status;
+GO


### PR DESCRIPTION
### Description

**Background: INSERT...EXEC Redesign**

The current INSERT...EXEC implementation has limitations with transaction handling, error recovery, and TRY-CATCH compatibility. We're redesigning it using a **temp table buffering approach**:
1. Procedure output is captured into a temporary buffer table via a custom DestReceiver
2. After procedure execution completes, buffered rows are flushed to the target table
3. This enables proper TRY-CATCH error handling and transaction semantics matching SQL Server

**PR Series Overview:**
| PR | Focus | Description |
|----|-------|-------------|
| PR0 | GUC | Feature flag to gate the new code path |
| PR1 | Parser | Parse INSERT...EXEC and extract target table info |
| PR2 | Executor | Core state management and schema detection |
| PR3 | DestReceiver | Capture procedure output to temp table |
| PR4 | Temp Table | Create/drop temp buffer table with correct schema |
| PR5 | Flush | Transfer buffered data to target table |
| **PR6** | **Integration** | **Wire everything together with tests** |

**PR Chain:** [← PR5](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4788) | None →

**This PR:**

Completes the INSERT...EXEC redesign by integrating all components into the executor and adding comprehensive tests. This is the final PR that wires everything together and enables the feature.

**What this enables:**
- Correct transaction semantics matching SQL Server behavior
- Proper column mapping and type coercion
- TRY-CATCH error handling
- Ownership chaining (procedures calling other procedures owned by the same user)
- Table variables (`@tablevar`) and temp tables (`#temp`) as targets
- INSTEAD OF triggers on target tables
- All syntax variations (procedures, dynamic SQL, sp_executesql)

**Files Changed:**
- **pl_exec-2.c**: Integrate INSERT EXEC setup/cleanup into `exec_stmt_exec`, `exec_stmt_exec_sp`, `exec_stmt_exec_batch`
- **pl_exec.c / iterative_exec.c**: Add INSERT EXEC context checks, transaction management integration
- **tdsresponse.c**: Route procedure output to INSERT EXEC DestReceiver when active
- **hooks.c**: Add DROP TABLE protection for active INSERT EXEC target tables (SQL Server error 556)
- **session.c**: Add INSERT EXEC state to session cleanup
- **error_mapping.txt**: Add error mappings for nested INSERT EXEC (8164), schema alteration (556)
- **Tests**: Comprehensive JDBC tests (BABEL-INSERT-EXEC.sql - 855 lines input, 1205 lines expected output)

**Related Engine PR:** https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/749
(Removes old tuple-store based INSERT EXEC hooks no longer needed with DestReceiver approach)

### Issues Resolved
PR6 of Task: [BABEL-5522](https://jira.rds.a2z.com/browse/BABEL-5522)

**Fixed Issues:**
- Transaction behavior inconsistencies with @@TRANCOUNT and implicit transactions
- Wrong column insertion when procedure output order differs from target
- Server crashes with nested procedures and complex error scenarios
- Memory leaks and improper cleanup
- OUTPUT clause not working with INSERT EXEC
- Various syntax parsing gaps for valid T-SQL
- Ownership chaining broken for INSERT EXEC
- Table variables (`@tablevar`) not recognized correctly
- Type coercion not handling typmod differences (e.g., varchar(max) to varchar(10))

### Test Scenarios Covered
* **Use case based -** Basic INSERT EXEC with procedures, dynamic SQL, sp_executesql; Multiple result sets; Ownership chaining scenarios; Column list specifications; Table variables and temp tables as targets; Nested procedure calls; INSTEAD OF triggers on target tables
* **Boundary conditions -** Empty result sets; Single row vs multiple rows; Maximum column counts; Type coercion edge cases (varchar(max) to varchar(10), int to datetime); Large result sets
* **Arbitrary inputs -** Various data types; NULL handling; Unicode data
* **Negative test cases -** Nested INSERT EXEC (error 8164); Column count mismatch (error 213); Type conversion failures; DROP TABLE on active target (error 556); Permission denied scenarios; Transaction errors
* **Minor version upgrade tests -** N/A (feature redesign)
* **Major version upgrade tests -** N/A (feature redesign)
* **Performance tests -** Basic performance validation with large result sets
* **Tooling impact -** None
* **Client tests -** JDBC tests: BABEL-INSERT-EXEC, BABEL-INSERT-EXECUTE, proc_ownership_chaining, BABEL-2999, temp_table_rollback, BABEL-1944, datareader_datawriter

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.
