### PR TITLE
fix: Add range validation in DATE to DATETIME2 cast [5.x backport]

### DIFF
--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -9,6 +9,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "common/int.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
@@ -491,7 +492,22 @@ date_datetime2(PG_FUNCTION_ARGS)
 	else if (DATE_IS_NOEND(dateVal))
 		TIMESTAMP_NOEND(result);
 	else
-		result = dateVal * USECS_PER_DAY;
+	{
+		/*
+		 * Use overflow-safe multiplication to prevent int64 overflow.
+		 * dateVal * USECS_PER_DAY can overflow for dates outside the
+		 * valid datetime2 range (0001-01-01 to 9999-12-31).
+		 */
+		int64		product;
+
+		if (pg_mul_s64_overflow((int64) dateVal, USECS_PER_DAY, &product) ||
+			!IS_VALID_DATETIME2(product))
+			ereport(ERROR,
+					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+					 errmsg("data out of range for datetime2")));
+
+		result = (Timestamp) product;
+	}
 
 	PG_RETURN_TIMESTAMP(result);
 }

--- a/test/JDBC/expected/cast_date_to_datetime2.out
+++ b/test/JDBC/expected/cast_date_to_datetime2.out
@@ -1,0 +1,49 @@
+
+-- Test DATE to DATETIME2 cast with out-of-range dates (BABEL-4527)
+-- Out-of-range: year 999999 (exceeds datetime2 max of 9999-12-31)
+SELECT CAST(CAST('999999-12-31' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data out of range for datetime2)~~
+
+
+-- Out-of-range: year 10000 (just past valid range)
+SELECT CAST(CAST('10000-01-01' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data out of range for datetime2)~~
+
+
+-- Valid boundary: max datetime2 date
+SELECT CAST(CAST('9999-12-31' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+9999-12-31 00:00:00.0000000
+~~END~~
+
+
+-- Out-of-range: date before datetime2 min (PostgreSQL min date, 4714-11-24 BC)
+SELECT CAST(CAST('4714-11-24 BC' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data out of range for datetime2)~~
+
+
+-- Valid boundary: min datetime2 date
+SELECT CAST(CAST('0001-01-01' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+0001-01-01 00:00:00.0000000
+~~END~~
+

--- a/test/JDBC/input/cast_date_to_datetime2.sql
+++ b/test/JDBC/input/cast_date_to_datetime2.sql
@@ -1,0 +1,21 @@
+-- Test DATE to DATETIME2 cast with out-of-range dates (BABEL-4527)
+
+-- Out-of-range: year 999999 (exceeds datetime2 max of 9999-12-31)
+SELECT CAST(CAST('999999-12-31' AS DATE) AS datetime2);
+GO
+
+-- Out-of-range: year 10000 (just past valid range)
+SELECT CAST(CAST('10000-01-01' AS DATE) AS datetime2);
+GO
+
+-- Valid boundary: max datetime2 date
+SELECT CAST(CAST('9999-12-31' AS DATE) AS datetime2);
+GO
+
+-- Out-of-range: date before datetime2 min (PostgreSQL min date, 4714-11-24 BC)
+SELECT CAST(CAST('4714-11-24 BC' AS DATE) AS datetime2);
+GO
+
+-- Valid boundary: min datetime2 date
+SELECT CAST(CAST('0001-01-01' AS DATE) AS datetime2);
+GO


### PR DESCRIPTION
## Description

Backport of #4798 to BABEL_5_X_DEV.

CAST(DATE AS DATETIME2) hangs for dates outside the valid datetime2 range (0001-01-01 to 9999-12-31) because the multiplication `dateVal * USECS_PER_DAY` overflows int64.

This adds a pre-multiplication bounds check in `date_datetime2()` to raise `data out of range for datetime2` for out-of-range input dates.

## Changes

- **contrib/babelfishpg_common/src/datetime2.c**: Added bounds check before the `dateVal * USECS_PER_DAY` multiplication to prevent int64 overflow
- **test/JDBC/input/cast_date_to_datetime2.sql**: New test file with boundary and out-of-range cases
- **test/JDBC/expected/cast_date_to_datetime2.out**: Expected output for the new tests

## Testing

- Out-of-range dates (year 10000, year 999999) now raise an error instead of hanging
- Valid boundary dates (0001-01-01, 9999-12-31) continue to work correctly

Task: BABEL-4527
Signed-off-by: Kristian Lejao <klejao@amazon.com>