### PR TITLE
Remove unnecessary PG_TRY blocks and refactor duplicated cleanup to PG_FINALLY

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/fault_injection/fault_injection.c
+++ b/contrib/babelfishpg_tds/src/backend/fault_injection/fault_injection.c
@@ -249,17 +249,12 @@ TriggerFault(FaultInjectorType_e type, void *arg)
 			TDS_DEBUG(TDS_DEBUG2, "Triggering fault: %s", entry->faultName);
 			(*(entry->fault_callback)) (arg, &(entry->num_occurrences));
 		}
-		PG_CATCH();
+		PG_FINALLY();
 		{
 			if (entry->num_occurrences == 0)
 				FaultInjectionDisableTest(entry);
-
-			PG_RE_THROW();
 		}
 		PG_END_TRY();
-
-		if (entry->num_occurrences == 0)
-			FaultInjectionDisableTest(entry);
 
 		return;
 	}

--- a/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdslogin.c
@@ -1971,31 +1971,23 @@ TdsProcessLogin(Port *port, bool loadedSsl)
 	TdsErrorContext->phase = 0;
 	TdsErrorContext->reqType = TDS_LOGIN7;
 
-	PG_TRY();
-	{
-		TdsErrorContext->err_text = "Parsing PreLogin Request";
-		/* Pre-Login */
-		rc = ParsePreLoginRequest();
-		if (rc < 0)
-			return rc;
+	TdsErrorContext->err_text = "Parsing PreLogin Request";
+	/* Pre-Login */
+	rc = ParsePreLoginRequest();
+	if (rc < 0)
+		return rc;
 
-		TdsErrorContext->err_text = "Make PreLogin Response";
+	TdsErrorContext->err_text = "Make PreLogin Response";
 
-		loadEncryption = MakePreLoginResponse(port, loadedSsl);
-		TdsFlush();
+	loadEncryption = MakePreLoginResponse(port, loadedSsl);
+	TdsFlush();
 
-		TdsErrorContext->err_text = "Setup SSL Handshake";
-		/* Setup the SSL handshake */
-		if (loadEncryption == TDS_ENCRYPT_ON ||
-			loadEncryption == TDS_ENCRYPT_OFF ||
-			loadEncryption == TDS_ENCRYPT_REQ)
-			rc = SecureOpenServer(port);
-	}
-	PG_CATCH();
-	{
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	TdsErrorContext->err_text = "Setup SSL Handshake";
+	/* Setup the SSL handshake */
+	if (loadEncryption == TDS_ENCRYPT_ON ||
+		loadEncryption == TDS_ENCRYPT_OFF ||
+		loadEncryption == TDS_ENCRYPT_REQ)
+		rc = SecureOpenServer(port);
 
 	/*
 	 * If SSL handshake failure has occurred then no need to go ahead with
@@ -2007,16 +1999,8 @@ TdsProcessLogin(Port *port, bool loadedSsl)
 	if (loadEncryption == TDS_ENCRYPT_ON)
 		TDSInstrumentation(INSTR_TDS_LOGIN_END_TO_END_ENCRYPT);
 
-	PG_TRY();
-	{
-		/* Login */
-		rc = ProcessLoginInternal(port);
-	}
-	PG_CATCH();
-	{
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	/* Login */
+	rc = ProcessLoginInternal(port);
 
 	TdsErrorContext->err_text = "";
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsprotocol.c
@@ -249,173 +249,165 @@ GetTDSRequest(bool *resetProtocol)
 	TdsErrorContext->err_text = "Fetching TDS Request";
 	TdsErrorContext->spType = "Unknown (Pre-Parsing Request)";
 	TdsErrorContext->txnType = "Unknown (Pre-Parsing Request)";
-	PG_TRY();
+	/*
+	 * If we've saved the TDS request earlier, process the same instead of
+	 * trying to fetch a new request.
+	 */
+	if (resetCon != NULL)
+	{
+		messageType = resetCon->messageType;
+		status = resetCon->status;
+		appendBinaryStringInfo(&message, resetCon->message->data, resetCon->message->len);
+
+		/* cleanup and reset */
+		pfree(resetCon->message->data);
+		pfree(resetCon->message);
+		pfree(resetCon);
+		resetCon = NULL;
+	}
+	else
 	{
 		/*
-		 * If we've saved the TDS request earlier, process the same instead of
-		 * trying to fetch a new request.
+		 * If TdsRequestCtrl->request is not NULL then there are mutliple
+		 * RPCs in a Batch and we would restore the message Otherwise we
+		 * would fetch the next packet.]
 		 */
-		if (resetCon != NULL)
+		if (TdsRequestCtrl->request == NULL)
 		{
-			messageType = resetCon->messageType;
-			status = resetCon->status;
-			appendBinaryStringInfo(&message, resetCon->message->data, resetCon->message->len);
+			int			ret;
 
-			/* cleanup and reset */
-			pfree(resetCon->message->data);
-			pfree(resetCon->message);
-			pfree(resetCon);
-			resetCon = NULL;
+			/*
+			 * We should hold the interrupts untill we read the entire
+			 * request.
+			 */
+			HOLD_CANCEL_INTERRUPTS();
+			ret = TdsReadNextRequest(&message, &status, &messageType);
+			RESUME_CANCEL_INTERRUPTS();
+
+			if (ret != 0)
+			{
+				TdsErrorContext->reqType = 0;
+				TdsErrorContext->err_text = "EOF reached on TDS socket";
+				TDS_DEBUG(TDS_DEBUG1, "EOF on TDS socket");
+				pfree(message.data);
+				return NULL;
+			}
+			TdsErrorContext->err_text = "Fetching TDS Request";
+			TdsRequestCtrl->status = status;
 		}
 		else
-		{
-			/*
-			 * If TdsRequestCtrl->request is not NULL then there are mutliple
-			 * RPCs in a Batch and we would restore the message Otherwise we
-			 * would fetch the next packet.]
-			 */
-			if (TdsRequestCtrl->request == NULL)
-			{
-				int			ret;
+			RestoreRPCBatch(&message, &status, &messageType);
+	}
 
-				/*
-				 * We should hold the interrupts untill we read the entire
-				 * request.
-				 */
-				HOLD_CANCEL_INTERRUPTS();
-				ret = TdsReadNextRequest(&message, &status, &messageType);
-				RESUME_CANCEL_INTERRUPTS();
+	DebugPrintMessageData("Fetched message:", message);
 
-				if (ret != 0)
-				{
-					TdsErrorContext->reqType = 0;
-					TdsErrorContext->err_text = "EOF reached on TDS socket";
-					TDS_DEBUG(TDS_DEBUG1, "EOF on TDS socket");
-					pfree(message.data);
-					return NULL;
-				}
-				TdsErrorContext->err_text = "Fetching TDS Request";
-				TdsRequestCtrl->status = status;
-			}
-			else
-				RestoreRPCBatch(&message, &status, &messageType);
-		}
-
-		DebugPrintMessageData("Fetched message:", message);
-
-		TdsErrorContext->reqType = messageType;
+	TdsErrorContext->reqType = messageType;
 
 #ifdef FAULT_INJECTOR
-		{
-			TdsMessageWrapper wrapper;
+	{
+		TdsMessageWrapper wrapper;
 
-			wrapper.message = &message;
-			wrapper.messageType = messageType;
+		wrapper.message = &message;
+		wrapper.messageType = messageType;
 
-			FAULT_INJECT(PreParsingType, &wrapper);
-		}
+		FAULT_INJECT(PreParsingType, &wrapper);
+	}
 #endif
 
-		Assert(messageType != 0);
+	Assert(messageType != 0);
 
-		/*
-		 * If we have to reset the connection, we save the TDS request in top
-		 * memory context before exit so that we can process the request
-		 * later.
-		 */
-		if (status & TDS_PACKET_HEADER_STATUS_RESETCON)
-		{
-			MemoryContextSwitchTo(TopMemoryContext);
-
-			if (resetCon == NULL)
-				resetCon = palloc(sizeof(ResetConnectionData));
-
-			resetCon->message = makeStringInfo();
-			appendBinaryStringInfo(resetCon->message, message.data, message.len);
-			resetCon->messageType = messageType;
-			resetCon->status = (status & ~TDS_PACKET_HEADER_STATUS_RESETCON);
-
-			/*
-			 * Set resetTdsConnectionFlag to true so that we avoid
-			 * sending any env change token for the USE DB command
-			 * which will get executed.
-			 */
-			resetTdsConnectionFlag = true;
-			TdsSetDbContext();
-			resetTdsConnectionFlag = false;
-			ResetTDSConnection();
-
-			TdsErrorContext->err_text = "Fetching TDS Request";
-			*resetProtocol = true;
-			return NULL;
-		}
-
-		/*
-		 * XXX: We don't support the following feature.  But, throw an error
-		 * to detect the case in case we get such a request.
-		 */
-		if (status & TDS_PACKET_HEADER_STATUS_RESETCONSKIPTRAN)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					 errmsg("RESETCONSKIPTRAN is not supported")));
-
-		/* An attention request can also have message.len = 0. */
-		if (message.len == 0 && messageType != TDS_ATTENTION)
-		{
-			TDS_DEBUG(TDS_DEBUG1, "zero byte client message on TDS socket");
-			pfree(message.data);
-			return NULL;
-		}
-
-		/*
-		 * Enable statement timeout. Note we add this function here to include
-		 * the time taken by the protocol in the timeout.
-		 */
-		enable_statement_timeout();
-
-		/* Parse the packet */
-		switch (messageType)
-		{
-			case TDS_QUERY:		/* Simple SQL BATCH */
-				{
-					request = GetSQLBatchRequest(&message);
-
-					pfree(message.data);
-				}
-				break;
-			case TDS_RPC:		/* Remote procedure call */
-				{
-					request = GetRPCRequest(&message);
-				}
-				break;
-			case TDS_TXN:		/* Transaction management request */
-				{
-					request = GetTxnMgmtRequest(&message);
-				}
-				break;
-			case TDS_BULK_LOAD: /* Bulk Load request */
-				{
-					request = GetBulkLoadRequest(&message);
-				}
-				break;
-			case TDS_ATTENTION: /* Attention request */
-				{
-					/* Return an empty request with the attention type. */
-					request = palloc0(sizeof(TDSRequest));
-					request->reqType = TDS_REQUEST_ATTN;
-				}
-				break;
-			default:
-				DebugPrintMessageData("Ignored message", message);
-				elog(ERROR, "TDSRequest: ignoring request type 0x%02x",
-					 message.data[0]);
-		}
-	}
-	PG_CATCH();
+	/*
+	 * If we have to reset the connection, we save the TDS request in top
+	 * memory context before exit so that we can process the request
+	 * later.
+	 */
+	if (status & TDS_PACKET_HEADER_STATUS_RESETCON)
 	{
-		PG_RE_THROW();
+		MemoryContextSwitchTo(TopMemoryContext);
+
+		if (resetCon == NULL)
+			resetCon = palloc(sizeof(ResetConnectionData));
+
+		resetCon->message = makeStringInfo();
+		appendBinaryStringInfo(resetCon->message, message.data, message.len);
+		resetCon->messageType = messageType;
+		resetCon->status = (status & ~TDS_PACKET_HEADER_STATUS_RESETCON);
+
+		/*
+		 * Set resetTdsConnectionFlag to true so that we avoid
+		 * sending any env change token for the USE DB command
+		 * which will get executed.
+		 */
+		resetTdsConnectionFlag = true;
+		TdsSetDbContext();
+		resetTdsConnectionFlag = false;
+		ResetTDSConnection();
+
+		TdsErrorContext->err_text = "Fetching TDS Request";
+		*resetProtocol = true;
+		return NULL;
 	}
-	PG_END_TRY();
+
+	/*
+	 * XXX: We don't support the following feature.  But, throw an error
+	 * to detect the case in case we get such a request.
+	 */
+	if (status & TDS_PACKET_HEADER_STATUS_RESETCONSKIPTRAN)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("RESETCONSKIPTRAN is not supported")));
+
+	/* An attention request can also have message.len = 0. */
+	if (message.len == 0 && messageType != TDS_ATTENTION)
+	{
+		TDS_DEBUG(TDS_DEBUG1, "zero byte client message on TDS socket");
+		pfree(message.data);
+		return NULL;
+	}
+
+	/*
+	 * Enable statement timeout. Note we add this function here to include
+	 * the time taken by the protocol in the timeout.
+	 */
+	enable_statement_timeout();
+
+	/* Parse the packet */
+	switch (messageType)
+	{
+		case TDS_QUERY:		/* Simple SQL BATCH */
+			{
+				request = GetSQLBatchRequest(&message);
+
+				pfree(message.data);
+			}
+			break;
+		case TDS_RPC:		/* Remote procedure call */
+			{
+				request = GetRPCRequest(&message);
+			}
+			break;
+		case TDS_TXN:		/* Transaction management request */
+			{
+				request = GetTxnMgmtRequest(&message);
+			}
+			break;
+		case TDS_BULK_LOAD: /* Bulk Load request */
+			{
+				request = GetBulkLoadRequest(&message);
+			}
+			break;
+		case TDS_ATTENTION: /* Attention request */
+			{
+				/* Return an empty request with the attention type. */
+				request = palloc0(sizeof(TDSRequest));
+				request->reqType = TDS_REQUEST_ATTN;
+			}
+			break;
+		default:
+			DebugPrintMessageData("Ignored message", message);
+			elog(ERROR, "TDSRequest: ignoring request type 0x%02x",
+				 message.data[0]);
+	}
 
 	FAULT_INJECT(PostParsingType, request);
 

--- a/contrib/babelfishpg_tsql/src/analyzer.c
+++ b/contrib/babelfishpg_tsql/src/analyzer.c
@@ -328,12 +328,9 @@ analyze(PLtsql_function *func, CompileContext *cmpl_ctx)
 		/* extra checks */
 		check_unsupported_goto(analyzer_ctx);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		destroy_template_context(walker);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	destroy_template_context(walker);
 }

--- a/contrib/babelfishpg_tsql/src/catalog.c
+++ b/contrib/babelfishpg_tsql/src/catalog.c
@@ -5205,18 +5205,13 @@ rename_tsql_db(char *old_db_name, char *new_db_name)
 			((*pltsql_protocol_plugin_ptr)->send_info) (0, 1, 0, message, 0);
 	
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		UnlockLogicalDatabaseForSession(dbid, ExclusiveLock, false);
 		SetUserIdAndSecContext(save_userid, save_sec_context);
 		SetCurrentRoleId(prev_current_user, true);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	UnlockLogicalDatabaseForSession(dbid, ExclusiveLock, false);
-	SetUserIdAndSecContext(save_userid, save_sec_context);
-	SetCurrentRoleId(prev_current_user, true);
 
 	if (!xactStarted)
 		CommitTransactionCommand();

--- a/contrib/babelfishpg_tsql/src/dbcmds.c
+++ b/contrib/babelfishpg_tsql/src/dbcmds.c
@@ -987,17 +987,12 @@ create_builtin_dbs(PG_FUNCTION_ARGS)
 		do_create_bbf_db(NULL, "master", NULL, sa_name);
 		do_create_bbf_db(NULL, "tempdb", NULL, sa_name);
 		do_create_bbf_db(NULL, "msdb", NULL, sa_name);
-		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  GUC_CONTEXT_CONFIG,
-						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	PG_RETURN_INT32(0);
@@ -1024,17 +1019,12 @@ create_msdb_if_not_exists(PG_FUNCTION_ARGS)
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 		create_bbf_db_internal(NULL, "msdb", NULL, sa_name, 4);
-		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  GUC_CONTEXT_CONFIG,
-						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
 	PG_RETURN_INT32(0);
@@ -1095,17 +1085,12 @@ drop_all_dbs(PG_FUNCTION_ARGS)
 			if (!tuple)
 				all_db_dropped = true;
 		}
-		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
-						  GUC_CONTEXT_CONFIG,
-						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", sql_dialect_value_old,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
 

--- a/contrib/babelfishpg_tsql/src/fts.c
+++ b/contrib/babelfishpg_tsql/src/fts.c
@@ -32,24 +32,16 @@ babelfish_fts_rewrite(PG_FUNCTION_ARGS)
                 errmsg("Full Text Search is not yet supported.")));
     }
     
-    PG_TRY();
-    {
-        // Switch to a suitable memory context if necessary
-        if (!CurrentMemoryContext) {
-            MemoryContextSwitchTo(TopMemoryContext);
-        }
-        fts_scanner_init(input_str);
-
-        if (fts_yyparse(&translated_query) != 0)
-            fts_yyerror(&translated_query, "fts parser failed");
-
-        fts_scanner_finish();
+    // Switch to a suitable memory context if necessary
+    if (!CurrentMemoryContext) {
+        MemoryContextSwitchTo(TopMemoryContext);
     }
-    PG_CATCH();
-    {
-        PG_RE_THROW();
-    }
-    PG_END_TRY();
+    fts_scanner_init(input_str);
+
+    if (fts_yyparse(&translated_query) != 0)
+        fts_yyerror(&translated_query, "fts parser failed");
+
+    fts_scanner_finish();
 
     if (translated_query) {
         result_text = cstring_to_text(translated_query);

--- a/contrib/babelfishpg_tsql/src/pl_comp.c
+++ b/contrib/babelfishpg_tsql/src/pl_comp.c
@@ -1000,13 +1000,11 @@ do_compile(FunctionCallInfo fcinfo,
 		analyze(function, cmpl_ctx);
 		gen_exec_code(function, cmpl_ctx);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		destroy_compile_context(cmpl_ctx);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	destroy_compile_context(cmpl_ctx);
 
 	return function;
 }
@@ -1347,13 +1345,11 @@ pltsql_compile_inline(char *proc_source, InlineCodeBlockArgs *args)
 		analyze(function, cmpl_ctx);
 		gen_exec_code(function, cmpl_ctx);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		destroy_compile_context(cmpl_ctx);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	destroy_compile_context(cmpl_ctx);
 
 	return function;
 }

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -1645,17 +1645,12 @@ execute_batch(PLtsql_execstate *estate, char *batch, InlineCodeBlockArgs *args, 
 		if (fcinfo->isnull)
 			elog(ERROR, "pltsql_inline_handler failed");
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		/* Delete temporary tables as ENR */
 		pltsql_remove_current_query_env();
-
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	/* Delete temporary tables as ENR */
-	pltsql_remove_current_query_env();
 
 	after_lxid = MyProc->vxid.lxid;
 
@@ -1876,13 +1871,11 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 												paramno, args->numargs, args->argtypes,
 												values, nulls);
 				}
-				PG_CATCH();
+				PG_FINALLY();
 				{
 					disable_sp_cursor_find_param_hook();
-					PG_RE_THROW();
 				}
 				PG_END_TRY();
-				disable_sp_cursor_find_param_hook();
 
 				if (ret > 0)
 					ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
@@ -1930,13 +1923,11 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 												   (ccopt_null ? NULL : &ccopt),
 												   args->numargs, args->argtypes);
 				}
-				PG_CATCH();
+				PG_FINALLY();
 				{
 					disable_sp_cursor_find_param_hook();
-					PG_RE_THROW();
 				}
 				PG_END_TRY();
-				disable_sp_cursor_find_param_hook();
 
 				if (ret > 0)
 					ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
@@ -2038,13 +2029,11 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 													paramno, args->numargs,
 													args->argtypes, values, nulls);
 				}
-				PG_CATCH();
+				PG_FINALLY();
 				{
 					disable_sp_cursor_find_param_hook();
-					PG_RE_THROW();
 				}
 				PG_END_TRY();
-				disable_sp_cursor_find_param_hook();
 
 				if (ret > 0)
 					ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -4816,12 +4816,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 	Portal		portal = NULL;
 	ListCell   *lc;
 	bool		is_returning = false;
-
-	/*
-	 * Temporarily disable FMTONLY as it is causing issues with Import-Export.
-	 * Reenable if a use-case is found.
-	 */
-	bool		fmtonly_enabled = true;
 	CmdType		cmd = CMD_UNKNOWN;
 	bool		enable_txn_in_triggers = !pltsql_disable_txn_in_triggers;
 	bool		support_tsql_trans = pltsql_support_tsql_transactions();
@@ -4873,7 +4867,7 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 			 * statements as exec statements that invoke
 			 * sp_describe_first_result_set.
 			 */
-			if (pltsql_fmtonly && !strcasestr(estate->func->fn_signature, "sp_describe_first_result_set") && fmtonly_enabled && strcasestr(stmt->sqlstmt->query, "SELECT *"))
+			if (pltsql_fmtonly && !strcasestr(estate->func->fn_signature, "sp_describe_first_result_set") && strcasestr(stmt->sqlstmt->query, "SELECT *"))
 			{
 				initStringInfo(&query);
 				appendStringInfo(&query, "SELECT TOP 0");

--- a/contrib/babelfishpg_tsql/src/pltsql_coerce.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_coerce.c
@@ -3833,17 +3833,13 @@ pltsql_text_name(PG_FUNCTION_ARGS)
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
-			PG_CATCH();
+			PG_FINALLY();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-				PG_RE_THROW();
 			}
 			PG_END_TRY();
-			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  GUC_CONTEXT_CONFIG,
-							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);
 		}
@@ -3895,17 +3891,13 @@ pltsql_bpchar_name(PG_FUNCTION_ARGS)
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 				n = (*cstr_to_name_hook) (VARDATA_ANY(s), len);
 			}
-			PG_CATCH();
+			PG_FINALLY();
 			{
 				set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 								  GUC_CONTEXT_CONFIG,
 								  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-				PG_RE_THROW();
 			}
 			PG_END_TRY();
-			set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-							  GUC_CONTEXT_CONFIG,
-							  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 			PG_RETURN_NAME(n);
 		}

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -392,16 +392,12 @@ pltsql_createFunction(ParseState *pstate, PlannedStmt *pstmt, const char *queryS
 			}
 		}
 
-		PG_CATCH();
+		PG_FINALLY();
 		{
 			if (needCleanup)
 				EventTriggerEndCompleteQuery();
-			PG_RE_THROW();
 		}
 		PG_END_TRY();
-
-		if (needCleanup)
-			EventTriggerEndCompleteQuery();
 
 		return true;
 	}
@@ -2689,13 +2685,11 @@ exec_grantschema_subcmds(const char *schema, const char *rolname, bool is_grant,
 						NULL);
 		}
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		SetUserIdAndSecContext(save_userid, save_sec_context);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	SetUserIdAndSecContext(save_userid, save_sec_context);
 }
 
 AclMode

--- a/contrib/babelfishpg_tsql/src/prepare.c
+++ b/contrib/babelfishpg_tsql/src/prepare.c
@@ -639,13 +639,11 @@ prepare_exec_codes(PLtsql_function *func, ExecCodes *exec_codes)
 					pltsql_destroy_econtext(&estate);
 					exec_eval_cleanup(&estate);
 				}
-				PG_CATCH();
+				PG_FINALLY();
 				{
 					pltsql_estate_cleanup();
-					PG_RE_THROW();
 				}
 				PG_END_TRY();
-				pltsql_estate_cleanup();
 				break;
 			}
 		case PLTSQL_STMT_EXEC:
@@ -659,13 +657,11 @@ prepare_exec_codes(PLtsql_function *func, ExecCodes *exec_codes)
 					pltsql_destroy_econtext(&estate);
 					exec_eval_cleanup(&estate);
 				}
-				PG_CATCH();
+				PG_FINALLY();
 				{
 					pltsql_estate_cleanup();
-					PG_RE_THROW();
 				}
 				PG_END_TRY();
-				pltsql_estate_cleanup();
 				break;
 			}
 		case PLTSQL_STMT_PUSH_RESULT:
@@ -682,14 +678,12 @@ prepare_exec_codes(PLtsql_function *func, ExecCodes *exec_codes)
 					pltsql_destroy_econtext(&estate);
 					exec_eval_cleanup(&estate);
 				}
-				PG_CATCH();
+				PG_FINALLY();
 				{
 					pltsql_estate_cleanup();
-					PG_RE_THROW();
 				}
 				PG_END_TRY();
 
-				pltsql_estate_cleanup();
 				break;
 			}
 		default:

--- a/contrib/babelfishpg_tsql/src/procedures.c
+++ b/contrib/babelfishpg_tsql/src/procedures.c
@@ -198,7 +198,7 @@ sp_prepare(PG_FUNCTION_ARGS)
 
 		execute_batch(estate, batch, args, NULL);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", old_dialect,
 						  GUC_CONTEXT_CONFIG,
@@ -207,17 +207,8 @@ sp_prepare(PG_FUNCTION_ARGS)
 						  true,
 						  0,
 						  false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	set_config_option("babelfishpg_tsql.sql_dialect", old_dialect,
-					  GUC_CONTEXT_CONFIG,
-					  PGC_S_SESSION,
-					  GUC_ACTION_SAVE,
-					  true,
-					  0,
-					  false);
 
 	values[0] = Int32GetDatum(args->handle);
 
@@ -1734,22 +1725,14 @@ create_xp_qv_in_master_dbo_internal(PG_FUNCTION_ARGS)
 
 	pfree(dbo_scm);
 
-	PG_TRY();
-	{
-		if ((rc = SPI_connect()) != SPI_OK_CONNECT)
-			elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
+	if ((rc = SPI_connect()) != SPI_OK_CONNECT)
+		elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 
-		if ((rc = SPI_execute(query, false, 1)) < 0)
-			elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
+	if ((rc = SPI_execute(query, false, 1)) < 0)
+		elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
 
-		if ((rc = SPI_finish()) != SPI_OK_FINISH)
-			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
-	}
-	PG_CATCH();
-	{
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	if ((rc = SPI_finish()) != SPI_OK_FINISH)
+		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	PG_RETURN_INT32(0);
 }
@@ -1823,25 +1806,17 @@ create_xp_instance_regread_in_master_dbo_internal(PG_FUNCTION_ARGS)
 
 	pfree(dbo_scm);
 
-	PG_TRY();
-	{
-		if ((rc = SPI_connect()) != SPI_OK_CONNECT)
-			elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
+	if ((rc = SPI_connect()) != SPI_OK_CONNECT)
+		elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 
-		if ((rc = SPI_execute(query, false, 1)) < 0)
-			elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
+	if ((rc = SPI_execute(query, false, 1)) < 0)
+		elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
 
-		if ((rc = SPI_execute(query2, false, 1)) < 0)
-			elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
+	if ((rc = SPI_execute(query2, false, 1)) < 0)
+		elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
 
-		if ((rc = SPI_finish()) != SPI_OK_FINISH)
-			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
-	}
-	PG_CATCH();
-	{
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
+	if ((rc = SPI_finish()) != SPI_OK_FINISH)
+		elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 
 	PG_RETURN_INT32(0);
 }
@@ -2203,17 +2178,13 @@ sp_addrole(PG_FUNCTION_ARGS)
 			CommandCounterIncrement();
 		}
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  GUC_CONTEXT_CONFIG,
-					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
 
@@ -2345,17 +2316,13 @@ sp_droprole(PG_FUNCTION_ARGS)
 			CommandCounterIncrement();
 		}
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  GUC_CONTEXT_CONFIG,
-					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
 
@@ -2517,17 +2484,13 @@ sp_addrolemember(PG_FUNCTION_ARGS)
 			CommandCounterIncrement();
 		}
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  GUC_CONTEXT_CONFIG,
-					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	pfree(physical_member_name);
 	pfree(physical_role_name);
 	PG_RETURN_VOID();
@@ -2683,17 +2646,13 @@ sp_droprolemember(PG_FUNCTION_ARGS)
 			CommandCounterIncrement();
 		}
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  GUC_CONTEXT_CONFIG,
-					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	pfree(physical_name);
 	PG_RETURN_VOID();
 }
@@ -3534,7 +3493,6 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 				);
 		}
 
-		PG_TRY();
 		{
 			char		nulls = 0;
 			MemoryContext savedPortalCxt;
@@ -3577,11 +3535,6 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 			if ((rc = SPI_finish()) != SPI_OK_FINISH)
 				elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 		}
-		PG_CATCH();
-		{
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
 	}
 	else
 	{
@@ -3595,22 +3548,14 @@ sp_babelfish_volatility(PG_FUNCTION_ARGS)
 
 		query = psprintf("ALTER FUNCTION %s %s;", function_signature, volatility);
 
-		PG_TRY();
-		{
-			if ((rc = SPI_connect()) != SPI_OK_CONNECT)
-				elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
+		if ((rc = SPI_connect()) != SPI_OK_CONNECT)
+			elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(rc));
 
-			if ((rc = SPI_execute(query, false, 1)) < 0)
-				elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
+		if ((rc = SPI_execute(query, false, 1)) < 0)
+			elog(ERROR, "SPI_execute failed: %s", SPI_result_code_string(rc));
 
-			if ((rc = SPI_finish()) != SPI_OK_FINISH)
-				elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
-		}
-		PG_CATCH();
-		{
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
+		if ((rc = SPI_finish()) != SPI_OK_FINISH)
+			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 	}
 
 	if (function_name)
@@ -3710,18 +3655,13 @@ sp_renamedb_internal(PG_FUNCTION_ARGS)
 
 		rename_tsql_db(old_db_name, new_db_name);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 					GUC_CONTEXT_CONFIG,
 					PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					GUC_CONTEXT_CONFIG,
-					PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 
 	if (old_db_name)
 		pfree(old_db_name);
@@ -3900,17 +3840,13 @@ sp_rename_internal(PG_FUNCTION_ARGS)
 		rename_extended_property(objtype_code, schema_name, curr_relname,
 								 obj_name, new_name);
 	}
-	PG_CATCH();
+	PG_FINALLY();
 	{
 		set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
 						  GUC_CONTEXT_CONFIG,
 						  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
-		PG_RE_THROW();
 	}
 	PG_END_TRY();
-	set_config_option("babelfishpg_tsql.sql_dialect", saved_dialect,
-					  GUC_CONTEXT_CONFIG,
-					  PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);
 	PG_RETURN_VOID();
 }
 
@@ -4254,7 +4190,6 @@ sp_enum_oledb_providers_internal(PG_FUNCTION_ARGS)
 						") subquery;"
 			, str_toupper(provider_name, strlen(provider_name), C_COLLATION_OID), provider_name);
 
-	PG_TRY();
 	{
 		MemoryContext	savedPortalCxt;
 		SPIPlanPtr	plan;
@@ -4293,11 +4228,6 @@ sp_enum_oledb_providers_internal(PG_FUNCTION_ARGS)
 		if ((rc = SPI_finish()) != SPI_OK_FINISH)
 			elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(rc));
 	}
-	PG_CATCH();
-	{
-		PG_RE_THROW();
-	}
-	PG_END_TRY();
 
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
### Description

Remove unnecessary PG_TRY blocks and refactor duplicated cleanup to PG_FINALLY.
Also removed a redundant variable fmtonly_enabled.


### Issues Resolved

[NO-JIRA]


### Test Cases

Existing regression test cases cover all of these paths.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).