### PR TITLE
[Test-only] Remove before upgrade file sys-fn-varbintohexsubstring-before-16_10-or-17_ from 17-4 schedule

### DIFF
--- a/test/JDBC/upgrade/17_4/schedule
+++ b/test/JDBC/upgrade/17_4/schedule
@@ -644,5 +644,4 @@ BABEL-1664-before-16_10-or-17_6
 babel_string_to_money_reg
 babel_convert_with_style
 forxml-raw-elements-before-17_9-or-18_3
-sys-fn-varbintohexsubstring-before-16_10-or-17_6
 forxml-path-elements-before-17_10-or-18_4


### PR DESCRIPTION
### Description

Remove before upgrade file `sys-fn-varbintohexsubstring-before-16_10-or-17_6` from 17-4 because this testfile is expected to be present after 17-5 and before 17-6.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).