### PR TITLE
[TEST-ONLY] Increasing the value of version length after community stamp 17.10

### DIFF
--- a/test/JDBC/expected/len-vu-verify.out
+++ b/test/JDBC/expected/len-vu-verify.out
@@ -622,7 +622,7 @@ SELECT
 GO
 ~~START~~
 int#!#int#!#int
-180#!#9#!#6
+181#!#9#!#6
 ~~END~~
 
 


### PR DESCRIPTION
### Description

Change required in version length after merging community stamp 17.10.

Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/759

### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).