### PR TITLE
Fix test files added incorrectly in FOR XML AUTO implementation

### DIFF
--- a/test/JDBC/upgrade/14_22/schedule
+++ b/test/JDBC/upgrade/14_22/schedule
@@ -503,5 +503,4 @@ forxml-raw-elements-before-17_9-or-18_3
 forxml-path-elements-before-17_10-or-18_4
 forxml-before-17_10-or-18_4
 forxml-auto-before-17_11-or-18_5
-babel_sqlvariant_coerce_type
 babel_sqlvariant_coerce_type_before_16_14-or-17_10-or-18_4

--- a/test/JDBC/upgrade/14_23/schedule
+++ b/test/JDBC/upgrade/14_23/schedule
@@ -503,5 +503,4 @@ forxml-raw-elements-before-17_9-or-18_3
 forxml-path-elements-before-17_10-or-18_4
 forxml-before-17_10-or-18_4
 forxml-auto-before-17_11-or-18_5
-babel_sqlvariant_coerce_type
 babel_sqlvariant_coerce_type_before_16_14-or-17_10-or-18_4

--- a/test/JDBC/upgrade/15_17/schedule
+++ b/test/JDBC/upgrade/15_17/schedule
@@ -609,5 +609,4 @@ forxml-raw-elements-before-17_9-or-18_3
 forxml-path-elements-before-17_10-or-18_4
 forxml-before-17_10-or-18_4
 forxml-auto-before-17_11-or-18_5
-babel_sqlvariant_coerce_type
 babel_sqlvariant_coerce_type_before_16_14-or-17_10-or-18_4

--- a/test/JDBC/upgrade/15_18/schedule
+++ b/test/JDBC/upgrade/15_18/schedule
@@ -609,5 +609,4 @@ forxml-raw-elements-before-17_9-or-18_3
 forxml-path-elements-before-17_10-or-18_4
 forxml-before-17_10-or-18_4
 forxml-auto-before-17_11-or-18_5
-babel_sqlvariant_coerce_type
 babel_sqlvariant_coerce_type_before_16_14-or-17_10-or-18_4

--- a/test/JDBC/upgrade/16_13/schedule
+++ b/test/JDBC/upgrade/16_13/schedule
@@ -652,5 +652,4 @@ sys-fn-varbintohexsubstring
 forxml-path-elements-before-17_10-or-18_4
 forxml-before-17_10-or-18_4
 forxml-auto-before-17_11-or-18_5
-babel_sqlvariant_coerce_type
 babel_sqlvariant_coerce_type_before_16_14-or-17_10-or-18_4

--- a/test/JDBC/upgrade/17_9/schedule
+++ b/test/JDBC/upgrade/17_9/schedule
@@ -679,5 +679,4 @@ forxml-raw-elements-before-17_9-or-18_3
 forxml-path-elements-before-17_10-or-18_4
 forxml-before-17_10-or-18_4
 forxml-auto-before-17_11-or-18_5
-babel_sqlvariant_coerce_type
 babel_sqlvariant_coerce_type_before_16_14-or-17_10-or-18_4


### PR DESCRIPTION
### Description

babel_sqlvariant_coerce_type file added incorrectly in few schedules files of previous versions during merge conflict resolution.
This PR removes them.

Authored-by: Japleen Kaur [amjj@amazon.com](mailto:amjj@amazon.com)
Signed-off-by: Japleen Kaur [amjj@amazon.com](mailto:amjj@amazon.com)

**Previous PR where this change was introduced:**

Add support for FOR XML AUTO mode [4688](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4688)

### Test Scenarios Covered ###
* **Use case based -** NA


* **Boundary conditions -** NA


* **Arbitrary inputs -** NA


* **Negative test cases -** NA


* **Minor version upgrade tests -** NA


* **Major version upgrade tests -** NA


* **Performance tests -** NA


* **Tooling impact -** NA


* **Client tests -** NA



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).