### PR TITLE
Fix xmlns:xsi placement for ELEMENTS XSINIL with ROOT in FOR XML RAW/PATH

### DIFF
--- a/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
+++ b/contrib/babelfishpg_tsql/src/tsql_for/forxml.c
@@ -89,11 +89,12 @@ typedef struct forxml_state
 {
 	StringInfo			xml_output;		/* Accumulated XML output */
 	forxml_auto_state  *auto_state;		/* AUTO mode state, NULL for other modes */
+	bool				has_root;		/* True if ROOT clause was specified */
 } forxml_state;
 
 static StringInfo for_xml_ffunc(PG_FUNCTION_ARGS);
-static void tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool elements, bool xsinil);
-static void tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool xsinil);
+static void tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool elements, bool xsinil, bool has_root);
+static void tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool xsinil, bool has_root);
 static void tsql_row_to_xml_auto(StringInfo state, Datum record, bool elements, bool xsinil, forxml_auto_state *auto_state);
 static void update_tsql_datatype_and_val(HeapTuple tuple, TupleDesc tupdesc, Oid *datatype_oid, Datum *colval, bool binary_base64, int i);
 static char *tsql_escape_xml(const char *str);
@@ -197,7 +198,8 @@ tsql_query_to_xml_sfunc(PG_FUNCTION_ARGS)
 		fstate->auto_state = NULL;
 		state = fstate->xml_output;
 		root_name = PG_ARGISNULL(5) ? NULL : text_to_cstring(PG_GETARG_TEXT_PP(5));
-		if (root_name != NULL && strlen(root_name) > 0)
+		fstate->has_root = (root_name != NULL && strlen(root_name) > 0);
+		if (fstate->has_root)
 		{
 			/*
 			 * We need to add an extra token to the beginning so that the
@@ -248,7 +250,7 @@ tsql_query_to_xml_sfunc(PG_FUNCTION_ARGS)
 	switch (mode)
 	{
 		case TSQL_FORXML_RAW:	/* FOR XML RAW */
-			tsql_row_to_xml_raw(state, record, element_name, binary_base64, elements, xsinil);
+			tsql_row_to_xml_raw(state, record, element_name, binary_base64, elements, xsinil, fstate->has_root);
 			break;
 		case TSQL_FORXML_AUTO:	/* FOR XML AUTO */
 			{
@@ -263,7 +265,7 @@ tsql_query_to_xml_sfunc(PG_FUNCTION_ARGS)
 			}
 			break;
 		case TSQL_FORXML_PATH:	/* FOR XML PATH */
-			tsql_row_to_xml_path(state, record, element_name, binary_base64, xsinil);
+			tsql_row_to_xml_path(state, record, element_name, binary_base64, xsinil, fstate->has_root);
 			break;
 		case TSQL_FORXML_EXPLICIT:
 
@@ -380,7 +382,7 @@ for_xml_ffunc(PG_FUNCTION_ARGS)
  * Map an SQL row to an XML element in RAW mode.
  */
 static void
-tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool elements, bool xsinil)
+tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool elements, bool xsinil, bool has_root)
 {
 	HeapTupleHeader td;
 	Oid             tupType;
@@ -419,8 +421,13 @@ tsql_row_to_xml_raw(StringInfo state, Datum record, const char *element_name, bo
 	{
 		if (elements)
 		{
-			/* ELEMENTS mode: <row><col>value</col></row> */
-			if (xsinil)
+			/*
+			 * ELEMENTS mode: <row><col>value</col></row>.
+			 * When XSINIL is set, xmlns:xsi normally goes on the row tag,
+			 * but when ROOT is present we already emitted it there, so
+			 * suppress the per-row declaration to match T-SQL behavior.
+			 */
+			if (xsinil && !has_root)
 				appendStringInfo(state, "<%s " XML_XMLNS_XSI ">", element_name);
 			else
 				appendStringInfo(state, "<%s>", element_name);
@@ -564,7 +571,7 @@ validate_attribute_centric_col_names_xml(const char *element_name, TupleDesc tup
  * Map an SQL row to an XML element in PATH mode.
  */
 static void
-tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool xsinil)
+tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, bool binary_base64, bool xsinil, bool has_root)
 {
 	HeapTupleHeader td;
 	Oid             tupType;
@@ -593,21 +600,25 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 
 	/*
 	 * each tuple is either contained in a "row" tag, or standalone if the
-	 * element_name is an empty string
+	 * element_name is an empty string.
+	 *
+	 * When XSINIL is set, xmlns:xsi normally goes on the row tag,
+	 * but when ROOT is present we already emitted it there, so suppress
+	 * the per-row declaration to match T-SQL behavior.
 	 */
 	if (element_name && strlen(element_name) > 0)
 	{
 		/* if "''" is the input path, ignore it per TSQL behavior */
 		if (has_att_centric)
 		{
-			if (xsinil)
+			if (xsinil && !has_root)
 				appendStringInfo(state, "<%s " XML_XMLNS_XSI, element_name);
 			else
 				appendStringInfo(state, "<%s", element_name);
 		}
 		else
 		{
-			if (xsinil)
+			if (xsinil && !has_root)
 				appendStringInfo(state, "<%s " XML_XMLNS_XSI ">", element_name);
 			else
 				appendStringInfo(state, "<%s>", element_name);
@@ -656,8 +667,13 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 				}
 				else
 				{
-					/* When PATH('') is used with XSINIL, add xmlns to each element */
-					if ((element_name && strlen(element_name) == 0) && xsinil)
+					/*
+					 * PATH('') + XSINIL emits xmlns:xsi on each column
+					 * element since there is no row tag to carry it.
+					 * When ROOT already declared it, suppress the per-column
+					 * declaration to match T-SQL behavior.
+					 */
+					if ((element_name && strlen(element_name) == 0) && xsinil && !has_root)
 						appendStringInfo(state, "<%s " XML_XMLNS_XSI ">%s</%s>",
 										 colname,
 										 map_sql_value_to_xml_value(colval, datatype_oid, true),
@@ -689,8 +705,13 @@ tsql_row_to_xml_path(StringInfo state, Datum record, const char *element_name, b
 
 				if (strncmp(NameStr(att->attname), "?column?", 8) != 0)
 				{
-					/* When PATH('') is used with XSINIL, add xmlns to each element */
-					if (element_name && strlen(element_name) == 0)
+					/*
+					 * PATH('') + XSINIL emits xmlns:xsi on each column
+					 * element since there is no row tag to carry it.
+					 * When ROOT already declared it, suppress the per-column
+					 * declaration to match T-SQL behavior.
+					 */
+					if (element_name && strlen(element_name) == 0 && !has_root)
 						appendStringInfo(state, "<%s " XML_XMLNS_XSI " " XML_XSI_NIL "/>", colname);
 					else
 						appendStringInfo(state, "<%s " XML_XSI_NIL "/>", colname);

--- a/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-elements-before-17_10-or-18_4-vu-verify.out
@@ -148,7 +148,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -173,7 +173,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -209,7 +209,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -218,7 +218,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -239,6 +239,43 @@ GO
 ~~START~~
 ntext
 <ID>2</ID><Name>Jane</Name>
+~~END~~
+
+
+-- PATH('') with ROOT — xmlns:xsi declared on ROOT only,
+-- per-column declarations suppressed.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID IN (1,3) FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department><ID>3</ID><Name>Bob</Name><Department>IT</Department></Data>
+~~END~~
+
+
+-- PATH('') with ROOT, mixed NULL columns.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/><ID>3</ID><Name>Bob</Name><Department>IT</Department><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Data>
+~~END~~
+
+
+-- PATH('') with ROOT, directive order swapped.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ROOT('Data'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Data>
+~~END~~
+
+
+-- PATH('') with ROOT and TYPE combined.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+~~START~~
+xml
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Data>
 ~~END~~
 
 
@@ -623,6 +660,33 @@ ntext
 ~~END~~
 
 
+-- PATH (no parens) + XSINIL + ROOT: xmlns:xsi declared once on root.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><ID>1</ID><Name>John</Name><Department>Sales</Department></row></Data>
+~~END~~
+
+
+-- PATH (no parens) + XSINIL + ROOT + TYPE.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+~~START~~
+xml
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><ID>1</ID><Name>John</Name><Department>Sales</Department></row></Data>
+~~END~~
+
+
+-- PATH (no parens) + XSINIL + ROOT, all-NULL row.
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/></row></Data>
+~~END~~
+
+
 -- NULL in element name position
 SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(NULL), ELEMENTS XSINIL;
 GO
@@ -694,7 +758,7 @@ FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><City xsi:nil="true"/><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><City>Boston</City><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Global Ltd</CustomerName><City>Chicago</City><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerOrder><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder><CustomerName>Tech Inc</CustomerName><City xsi:nil="true"/><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder><CustomerName xsi:nil="true"/><City>Boston</City><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder><CustomerName>Global Ltd</CustomerName><City>Chicago</City><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
 ~~END~~
 
 
@@ -837,7 +901,7 @@ EXEC forxml_path_elements_p4;
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -845,7 +909,7 @@ EXEC forxml_path_elements_p5;
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -930,7 +994,7 @@ SELECT @xml_var AS result;
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name></Employee><Employee><ID>4</ID><Name xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/></Employee></Data>
 ~~END~~
 
 
@@ -973,7 +1037,7 @@ SELECT * FROM forxml_path_elements_into3;
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -1118,7 +1182,7 @@ SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('E
 GO
 ~~START~~
 xml
-<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
 ~~END~~
 
 

--- a/test/JDBC/expected/forxml-path-elements-vu-verify.out
+++ b/test/JDBC/expected/forxml-path-elements-vu-verify.out
@@ -148,7 +148,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -173,7 +173,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -209,7 +209,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -218,7 +218,7 @@ SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('Employee'
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -239,6 +239,43 @@ GO
 ~~START~~
 ntext
 <ID>2</ID><Name>Jane</Name>
+~~END~~
+
+
+-- PATH('') with ROOT — xmlns:xsi declared on ROOT only,
+-- per-column declarations suppressed.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID IN (1,3) FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department><ID>3</ID><Name>Bob</Name><Department>IT</Department></Data>
+~~END~~
+
+
+-- PATH('') with ROOT, mixed NULL columns.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/><ID>3</ID><Name>Bob</Name><Department>IT</Department><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Data>
+~~END~~
+
+
+-- PATH('') with ROOT, directive order swapped.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ROOT('Data'), ELEMENTS XSINIL;
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Data>
+~~END~~
+
+
+-- PATH('') with ROOT and TYPE combined.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+~~START~~
+xml
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Data>
 ~~END~~
 
 
@@ -405,7 +442,7 @@ FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Acme Corp" City="New York"><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Acme Corp" City="New York"><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Tech Inc"><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" City="Boston"><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Global Ltd" City="Chicago"><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerOrder Name="Acme Corp" City="New York"><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder Name="Acme Corp" City="New York"><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder Name="Tech Inc"><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder City="Boston"><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder Name="Global Ltd" City="Chicago"><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
 ~~END~~
 
 
@@ -704,6 +741,33 @@ ntext
 ~~END~~
 
 
+-- PATH (no parens) + XSINIL + ROOT: xmlns:xsi declared once on root.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><ID>1</ID><Name>John</Name><Department>Sales</Department></row></Data>
+~~END~~
+
+
+-- PATH (no parens) + XSINIL + ROOT + TYPE.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+~~START~~
+xml
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><ID>1</ID><Name>John</Name><Department>Sales</Department></row></Data>
+~~END~~
+
+
+-- PATH (no parens) + XSINIL + ROOT, all-NULL row.
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
+GO
+~~START~~
+ntext
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><Col1 xsi:nil="true"/><Col2 xsi:nil="true"/></row></Data>
+~~END~~
+
+
 -- NULL in element name position
 SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(NULL), ELEMENTS XSINIL;
 GO
@@ -775,7 +839,7 @@ FOR XML PATH('CustomerOrder'), ELEMENTS XSINIL, ROOT('Data');
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Tech Inc</CustomerName><City xsi:nil="true"/><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName xsi:nil="true"/><City>Boston</City><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerName>Global Ltd</CustomerName><City>Chicago</City><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><CustomerOrder><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-01-15</OrderDate><TotalAmount>100.00</TotalAmount></CustomerOrder><CustomerOrder><CustomerName>Acme Corp</CustomerName><City>New York</City><OrderDate>2024-02-20</OrderDate><TotalAmount>250.00</TotalAmount></CustomerOrder><CustomerOrder><CustomerName>Tech Inc</CustomerName><City xsi:nil="true"/><OrderDate>2024-03-10</OrderDate><TotalAmount xsi:nil="true"/></CustomerOrder><CustomerOrder><CustomerName xsi:nil="true"/><City>Boston</City><OrderDate xsi:nil="true"/><TotalAmount>175.50</TotalAmount></CustomerOrder><CustomerOrder><CustomerName>Global Ltd</CustomerName><City>Chicago</City><OrderDate xsi:nil="true"/><TotalAmount xsi:nil="true"/></CustomerOrder></Data>
 ~~END~~
 
 
@@ -918,7 +982,7 @@ EXEC forxml_path_elements_p4;
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -926,7 +990,7 @@ EXEC forxml_path_elements_p5;
 GO
 ~~START~~
 ntext
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -1011,7 +1075,7 @@ SELECT @xml_var AS result;
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name></Employee><Employee><ID>2</ID><Name>Jane</Name></Employee><Employee><ID>3</ID><Name>Bob</Name></Employee><Employee><ID>4</ID><Name xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/></Employee></Data>
 ~~END~~
 
 
@@ -1054,7 +1118,7 @@ SELECT * FROM forxml_path_elements_into3;
 GO
 ~~START~~
 xml
-<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
+<Data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Data>
 ~~END~~
 
 
@@ -1121,7 +1185,7 @@ SELECT * FROM forxml_path_elements_dep_view4;
 GO
 ~~START~~
 ntext
-<Employees xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Employees>
+<Employees xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee><Employee><ID>2</ID><Name>Jane</Name><Department xsi:nil="true"/></Employee><Employee><ID>3</ID><Name>Bob</Name><Department>IT</Department></Employee><Employee><ID>4</ID><Name xsi:nil="true"/><Department xsi:nil="true"/></Employee><Employee><ID>5</ID><Name xsi:nil="true"/><Department>HR</Department></Employee></Employees>
 ~~END~~
 
 
@@ -1204,7 +1268,7 @@ SELECT (SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH('E
 GO
 ~~START~~
 xml
-<Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
+<Employee><ID>1</ID><Name>John</Name><Department>Sales</Department></Employee>
 ~~END~~
 
 

--- a/test/JDBC/expected/forxml-raw-elements-before-17_9-or-18_3-vu-verify.out
+++ b/test/JDBC/expected/forxml-raw-elements-before-17_9-or-18_3-vu-verify.out
@@ -302,7 +302,7 @@ SELECT 1 AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data');
 GO
 ~~START~~
 ntext
-<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a>1</a><b xsi:nil="true"/></row></data>
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a>1</a><b xsi:nil="true"/></row></data>
 ~~END~~
 
 
@@ -310,7 +310,25 @@ SELECT 1 AS a, NULL AS b FOR XML RAW, ROOT('data'), ELEMENTS XSINIL;
 GO
 ~~START~~
 ntext
-<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a>1</a><b xsi:nil="true"/></row></data>
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a>1</a><b xsi:nil="true"/></row></data>
+~~END~~
+
+
+-- RAW + XSINIL + ROOT + TYPE: xmlns:xsi declared once on the root element.
+SELECT 1 AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data'), TYPE;
+GO
+~~START~~
+xml
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a>1</a><b xsi:nil="true"/></row></data>
+~~END~~
+
+
+-- All-NULL row + XSINIL + ROOT: row tag still emitted (with xsi:nil on each col).
+SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data');
+GO
+~~START~~
+ntext
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a xsi:nil="true"/><b xsi:nil="true"/></row></data>
 ~~END~~
 
 
@@ -494,7 +512,7 @@ SELECT * FROM forxml_raw_elements_t1 FOR XML RAW('Employee'), ELEMENTS XSINIL, R
 GO
 ~~START~~
 ntext
-<Employees xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>1</id><name>John</name><salary>50000</salary><department>IT</department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>2</id><name>Jane</name><salary>60000</salary><department>HR</department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>3</id><name>Bob</name><salary xsi:nil="true"/><department>Finance</department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>4</id><name>Alice</name><salary>70000</salary><department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>5</id><name xsi:nil="true"/><salary xsi:nil="true"/><department xsi:nil="true"/></Employee></Employees>
+<Employees xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><id>1</id><name>John</name><salary>50000</salary><department>IT</department></Employee><Employee><id>2</id><name>Jane</name><salary>60000</salary><department>HR</department></Employee><Employee><id>3</id><name>Bob</name><salary xsi:nil="true"/><department>Finance</department></Employee><Employee><id>4</id><name>Alice</name><salary>70000</salary><department xsi:nil="true"/></Employee><Employee><id>5</id><name xsi:nil="true"/><salary xsi:nil="true"/><department xsi:nil="true"/></Employee></Employees>
 ~~END~~
 
 

--- a/test/JDBC/expected/forxml-raw-elements-vu-verify.out
+++ b/test/JDBC/expected/forxml-raw-elements-vu-verify.out
@@ -302,7 +302,7 @@ SELECT 1 AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data');
 GO
 ~~START~~
 ntext
-<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a>1</a><b xsi:nil="true"/></row></data>
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a>1</a><b xsi:nil="true"/></row></data>
 ~~END~~
 
 
@@ -310,7 +310,25 @@ SELECT 1 AS a, NULL AS b FOR XML RAW, ROOT('data'), ELEMENTS XSINIL;
 GO
 ~~START~~
 ntext
-<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a>1</a><b xsi:nil="true"/></row></data>
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a>1</a><b xsi:nil="true"/></row></data>
+~~END~~
+
+
+-- RAW + XSINIL + ROOT + TYPE: xmlns:xsi declared once on the root element.
+SELECT 1 AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data'), TYPE;
+GO
+~~START~~
+xml
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a>1</a><b xsi:nil="true"/></row></data>
+~~END~~
+
+
+-- All-NULL row + XSINIL + ROOT: row tag still emitted (with xsi:nil on each col).
+SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data');
+GO
+~~START~~
+ntext
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><a xsi:nil="true"/><b xsi:nil="true"/></row></data>
 ~~END~~
 
 
@@ -494,7 +512,7 @@ SELECT * FROM forxml_raw_elements_t1 FOR XML RAW('Employee'), ELEMENTS XSINIL, R
 GO
 ~~START~~
 ntext
-<Employees xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>1</id><name>John</name><salary>50000</salary><department>IT</department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>2</id><name>Jane</name><salary>60000</salary><department>HR</department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>3</id><name>Bob</name><salary xsi:nil="true"/><department>Finance</department></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>4</id><name>Alice</name><salary>70000</salary><department xsi:nil="true"/></Employee><Employee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><id>5</id><name xsi:nil="true"/><salary xsi:nil="true"/><department xsi:nil="true"/></Employee></Employees>
+<Employees xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><Employee><id>1</id><name>John</name><salary>50000</salary><department>IT</department></Employee><Employee><id>2</id><name>Jane</name><salary>60000</salary><department>HR</department></Employee><Employee><id>3</id><name>Bob</name><salary xsi:nil="true"/><department>Finance</department></Employee><Employee><id>4</id><name>Alice</name><salary>70000</salary><department xsi:nil="true"/></Employee><Employee><id>5</id><name xsi:nil="true"/><salary xsi:nil="true"/><department xsi:nil="true"/></Employee></Employees>
 ~~END~~
 
 
@@ -1962,6 +1980,15 @@ SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL, ROOT('data');
 GO
 ~~START~~
 ntext
+<data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">1</a><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/></data>
+~~END~~
+
+
+-- RAW('') + XSINIL + ROOT + TYPE: per-column xmlns:xsi preserved (T-SQL keeps it for RAW('')).
+SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL, ROOT('data'), TYPE;
+GO
+~~START~~
+xml
 <data xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><a xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">1</a><b xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/></data>
 ~~END~~
 

--- a/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-before-17_10-or-18_4-vu-verify.sql
@@ -112,6 +112,23 @@ GO
 SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS ABSENT;
 GO
 
+-- PATH('') with ROOT — xmlns:xsi declared on ROOT only,
+-- per-column declarations suppressed.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID IN (1,3) FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- PATH('') with ROOT, mixed NULL columns.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- PATH('') with ROOT, directive order swapped.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+-- PATH('') with ROOT and TYPE combined.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+
 -- ============================================
 -- SECTION 7: Multiple data types
 -- ============================================
@@ -285,6 +302,18 @@ GO
 
 -- Default element name (no name specified) with XSINIL
 SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH, ELEMENTS XSINIL;
+GO
+
+-- PATH (no parens) + XSINIL + ROOT: xmlns:xsi declared once on root.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- PATH (no parens) + XSINIL + ROOT + TYPE.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+
+-- PATH (no parens) + XSINIL + ROOT, all-NULL row.
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
 GO
 
 -- NULL in element name position

--- a/test/JDBC/input/forxml/forxml-path-elements-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-path-elements-vu-verify.sql
@@ -112,6 +112,23 @@ GO
 SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS ABSENT;
 GO
 
+-- PATH('') with ROOT — xmlns:xsi declared on ROOT only,
+-- per-column declarations suppressed.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID IN (1,3) FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- PATH('') with ROOT, mixed NULL columns.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- PATH('') with ROOT, directive order swapped.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ROOT('Data'), ELEMENTS XSINIL;
+GO
+
+-- PATH('') with ROOT and TYPE combined.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 2 FOR XML PATH(''), ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+
 -- ============================================
 -- SECTION 7: Multiple data types
 -- ============================================
@@ -336,6 +353,18 @@ GO
 
 -- Default element name (no name specified) with XSINIL
 SELECT ID, Name, Department FROM forxml_path_elements_t1 FOR XML PATH, ELEMENTS XSINIL;
+GO
+
+-- PATH (no parens) + XSINIL + ROOT: xmlns:xsi declared once on root.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
+GO
+
+-- PATH (no parens) + XSINIL + ROOT + TYPE.
+SELECT ID, Name, Department FROM forxml_path_elements_t1 WHERE ID = 1 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data'), TYPE;
+GO
+
+-- PATH (no parens) + XSINIL + ROOT, all-NULL row.
+SELECT NULL AS Col1, NULL AS Col2 FOR XML PATH, ELEMENTS XSINIL, ROOT('Data');
 GO
 
 -- NULL in element name position

--- a/test/JDBC/input/forxml/forxml-raw-elements-before-17_9-or-18_3-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-raw-elements-before-17_9-or-18_3-vu-verify.sql
@@ -139,6 +139,14 @@ GO
 SELECT 1 AS a, NULL AS b FOR XML RAW, ROOT('data'), ELEMENTS XSINIL;
 GO
 
+-- RAW + XSINIL + ROOT + TYPE: xmlns:xsi declared once on the root element.
+SELECT 1 AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data'), TYPE;
+GO
+
+-- All-NULL row + XSINIL + ROOT: row tag still emitted (with xsi:nil on each col).
+SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data');
+GO
+
 SELECT 1 AS a, 2 AS b FOR XML RAW, ELEMENTS, ROOT('MyRoot');
 GO
 

--- a/test/JDBC/input/forxml/forxml-raw-elements-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-raw-elements-vu-verify.sql
@@ -139,6 +139,14 @@ GO
 SELECT 1 AS a, NULL AS b FOR XML RAW, ROOT('data'), ELEMENTS XSINIL;
 GO
 
+-- RAW + XSINIL + ROOT + TYPE: xmlns:xsi declared once on the root element.
+SELECT 1 AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data'), TYPE;
+GO
+
+-- All-NULL row + XSINIL + ROOT: row tag still emitted (with xsi:nil on each col).
+SELECT NULL AS a, NULL AS b FOR XML RAW, ELEMENTS XSINIL, ROOT('data');
+GO
+
 SELECT 1 AS a, 2 AS b FOR XML RAW, ELEMENTS, ROOT('MyRoot');
 GO
 
@@ -933,6 +941,10 @@ GO
 
 -- RAW('') with ELEMENTS XSINIL and ROOT
 SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL, ROOT('data');
+GO
+
+-- RAW('') + XSINIL + ROOT + TYPE: per-column xmlns:xsi preserved (T-SQL keeps it for RAW('')).
+SELECT 1 AS a, NULL AS b FOR XML RAW(''), ELEMENTS XSINIL, ROOT('data'), TYPE;
 GO
 
 -- RAW('') with ELEMENTS XSINIL - all NULLs


### PR DESCRIPTION
### Description

When using ELEMENTS XSINIL together with ROOT in FOR XML RAW or PATH mode, Babelfish was placing the `xmlns:xsi` namespace declaration on each row element instead of on the ROOT element. T-SQL declares it once on the ROOT element only.

Before:
```xml
<data xmlns:xsi="..."><row xmlns:xsi="..."><a>1</a><b xsi:nil="true"/></row></data>
```

After:
```xml
<data xmlns:xsi="..."><row><a>1</a><b xsi:nil="true"/></row></data>
```

When ROOT already carries the `xmlns:xsi` declaration, the per-row declaration is now suppressed. Without ROOT, the per-row declaration is still emitted (matching T-SQL behavior for the no-ROOT case).


The aggregate now tracks a `has_root` flag, set when the ROOT open-tag is emitted, and threads it into the RAW and PATH emitters. When ROOT is present they skip the row-level `xmlns:xsi` since the ROOT already carries it; without ROOT the existing emission is unchanged. The same flag also handles `PATH('')` with XSINIL (where xmlns would otherwise repeat on each column element) and `RAW('')` with XSINIL — there the ROOT tag itself now correctly includes `xmlns:xsi`.

Cherry-picked from [4835](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4835)

Authored-by: Japleen Kaur [amjj@amazon.com](mailto:amjj@amazon.com)
Signed-off-by: Japleen Kaur [amjj@amazon.com](mailto:amjj@amazon.com)

### Issues Resolved

JIRA : BABEL-6429

### Test Scenarios Covered ###
* **Use case based -** Yes. Existing tests in `forxml-raw-elements-vu-verify.sql` and `forxml-path-elements-vu-verify.sql` cover XSINIL + ROOT combinations (RAW, RAW(''), PATH, PATH(''), multiple rows, NULL columns, mixed attribute/element-centric).

* **Boundary conditions -** Yes. RAW('') empty element name with XSINIL + ROOT is covered (the special case).

* **Arbitrary inputs -** NA

* **Negative test cases -** NA 

* **Minor version upgrade tests -** Yes. `forxml-raw-elements-before-17_10-or-18_4` and `forxml-path-elements-before-17_10-or-18_4` expected files updated.

* **Major version upgrade tests -** NA

* **Performance tests -** NA 

* **Tooling impact -** NA

* **Client tests -** NA


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).