### PR TITLE
Adding ANALYZE in 1_GRANT_SCHEMA test

### DIFF
--- a/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
+++ b/test/JDBC/expected/1_GRANT_SCHEMA-vu-verify.out
@@ -1,3 +1,13 @@
+-- psql
+ANALYZE pg_catalog.pg_class;
+ANALYZE pg_catalog.pg_namespace;
+ANALYZE pg_catalog.pg_proc;
+ANALYZE pg_catalog.pg_type;
+ANALYZE pg_catalog.pg_attribute;
+ANALYZE sys.babelfish_namespace_ext;
+ANALYZE sys.babelfish_sysdatabases;
+GO
+
 -- tsql
 -- check for inconsistent metadata after upgrade
 select COUNT(*) FROM sys.babelfish_inconsistent_metadata();

--- a/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
+++ b/test/JDBC/input/1_GRANT_SCHEMA-vu-verify.mix
@@ -1,3 +1,13 @@
+-- psql
+ANALYZE pg_catalog.pg_class;
+ANALYZE pg_catalog.pg_namespace;
+ANALYZE pg_catalog.pg_proc;
+ANALYZE pg_catalog.pg_type;
+ANALYZE pg_catalog.pg_attribute;
+ANALYZE sys.babelfish_namespace_ext;
+ANALYZE sys.babelfish_sysdatabases;
+GO
+
 -- tsql
 -- check for inconsistent metadata after upgrade
 select COUNT(*) FROM sys.babelfish_inconsistent_metadata();


### PR DESCRIPTION
### Description

babelfish_inconsistent_metadata() scans multiple catalog tables internally and can be slow with stale statistics. Added targeted ANALYZE on key catalog tables before the consistency check to ensure reliable performance.

### Issues Resolved

No JIRA

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).