### PR TITLE
Fix OOB read and harden allocation-size math in MultiLineString varbinary parsing

### DIFF
--- a/contrib/babelfishpg_common/src/spatialtypes.c
+++ b/contrib/babelfishpg_common/src/spatialtypes.c
@@ -1974,6 +1974,17 @@ validate_multi_figures(GeometryData *geom_data, uint32_t npoints,  uint8_t expec
             THROW_VARBINARY_CONVERSION_ERROR();
         if (geom_data->shapes[i].type != expected_child_type)
             THROW_VARBINARY_CONVERSION_ERROR();
+
+        /*
+         * A non-empty multi-type child must reference a real figure. The
+         * 0xFFFFFFFF sentinel is only valid for empty geometries, which take
+         * a separate path via handle_empty_geometry_bytea() and never reach
+         * here. get_child_info() later uses this offset as an index into the
+         * figures array, so an unchecked 0xFFFFFFFF would cause an
+         * out-of-bounds read. Reject any out-of-range offset.
+         */
+        if (geom_data->shapes[i].figure_offset >= geom_data->nfigures)
+            THROW_VARBINARY_CONVERSION_ERROR();
     }
 
     /* Validate figure attributes based on child type */
@@ -2390,6 +2401,7 @@ handle_multi_to_postgis(GeometryData *geom_data)
     bool     has_m = (geom_data->dimension_flag == DIM_FLAG_2DM || geom_data->dimension_flag == DIM_FLAG_3DM);
     uint32_t nchildren = geom_data->nshapes - 1;  /* exclude root shape */
     uint32_t result_size;
+    uint64_t accum_size;
     uint8    postgis_header[POSTGIS_HEADER_SIZE];
     uint8    postgis_type_byte;
     bytea   *result;
@@ -2413,16 +2425,24 @@ handle_multi_to_postgis(GeometryData *geom_data)
     /* Source coordinate data base (after header + npoints) */
     src = geom_data->input_data + HEADER_SIZE + NPOINTS_SIZE;
 
-    /* Calculate total WKB size: header + SRID + nchildren(4) + all children */
-    result_size = POSTGIS_HEADER_SIZE + SRID_SIZE + sizeof(uint32_t);
+    /*
+     * Calculate total WKB size: header + SRID + nchildren(4) + all children.
+     * Accumulate in uint64 so that many children near the individual
+     * MaxAllocSize cap cannot wrap a uint32 and yield an undersized palloc.
+     */
+    accum_size = (uint64_t) POSTGIS_HEADER_SIZE + SRID_SIZE + sizeof(uint32_t);
 
     for (i = 0; i < nchildren; i++)
     {
         uint32_t pt_start, child_npoints, fig_start, fig_end;
         get_child_info(geom_data, i + 1, &pt_start, &child_npoints, &fig_start, &fig_end);
 
-        result_size += calculate_child_wkb_size(geom_data->geom_name, child_npoints, has_z, has_m);
+        accum_size += calculate_child_wkb_size(geom_data->geom_name, child_npoints, has_z, has_m);
+        if (accum_size > MaxAllocSize)
+            THROW_VARBINARY_CONVERSION_ERROR();
     }
+
+    result_size = (uint32_t) accum_size;
 
     /* Build PostGIS header */
     memcpy(postgis_header, POSTGIS_HEADER_MULTIPOINT, POSTGIS_HEADER_SIZE);


### PR DESCRIPTION
## Description

  Currently, the CLR-binary → PostGIS conversion path for spatial types (reached via `CAST(0x... AS sys.geometry)`) does not fully validate attacker-controllable fields
  in the serialized MultiLineString/MultiPoint layout. With this change, two such gaps introduced in the MultiLineString support work (#4831) are closed so that
  malformed input is rejected with a clean conversion error instead of crashing the backend or corrupting downstream processing.

  - **What it used to do:** `parse_figures_and_shapes()` accepted a child shape `figure_offset` of `0xFFFFFFFF` for any shape, because the bounds check explicitly
  exempted that sentinel. The `0xFFFFFFFF` sentinel is only meaningful for *empty* geometries, which take a separate path (`handle_empty_geometry_bytea`, selected when
  `npoints == 0`) and never reach this code. A crafted *non-empty* MultiLineString/MultiPoint with a child `figure_offset = 0xFFFFFFFF` therefore passed validation, and
  `get_child_info()` later used that value to index the `figures[]` array — an out-of-bounds read far past the allocated buffer, crashing the backend. Separately,
  `handle_multi_to_postgis()` accumulated the output WKB size in a `uint32_t` and only checked each child against `MaxAllocSize`, never the running total.
  - **What it does now:** non-empty multi-geometry child shapes must reference a valid in-range figure; any out-of-range `figure_offset` (including the `0xFFFFFFFF`
  sentinel) is rejected with the standard varbinary-conversion error before it can be dereferenced. The output-size accumulator now uses a `uint64_t` and is checked
  against `MaxAllocSize` on every iteration, consistent with the existing per-child check in `calculate_child_wkb_size()`.
  - **Why:** the `figure_offset` gap is an out-of-bounds read reachable by any authenticated user that crashes the backend (denial of service). The accumulator change is
  defense-in-depth to keep the allocation-size math overflow-safe and consistent across the multi-geometry code.

  ## Issues Resolved

  Security-review findings on PR #4831 (MultiLineString support):

  - **Issue 1 (blocking):** out-of-bounds read via child `figure_offset = 0xFFFFFFFF` on non-empty multi-geometries in `parse_figures_and_shapes()` / `get_child_info()`.
  - **Issue 4 (defense-in-depth):** potential `uint32` overflow of the `result_size` accumulator in `handle_multi_to_postgis()`.

  ## Test Scenarios Covered

  - **Use case based -** Existing MultiLineString / MultiPoint varbinary and WKT round-trip conversions (2D / 3D / ZM / EMPTY) continue to convert correctly and return
  identical results.
  - **Boundary conditions -** Child `figure_offset` exactly at `nfigures` (rejected) vs. `nfigures - 1` (accepted); single-child multi-geometry; empty multi-geometry
  (routed through the separate empty path, unaffected).
  - **Arbitrary inputs -** Crafted varbinary blobs with mismatched figure/shape metadata exercised through `CAST(0x... AS sys.geometry)`.
  - **Negative test cases -** Crafted non-empty child with `figure_offset = 0xFFFFFFFF` (and other out-of-range offsets) now returns `"Error converting data type
  varbinary"` instead of crashing the backend.
  - **Minor version upgrade tests -** N/A — no catalog/SQL object changes; C-only validation fix.
  - **Major version upgrade tests -** N/A — no catalog/SQL object changes.
  - **Performance tests -** N/A — adds one integer comparison per child shape on the conversion path; no measurable impact.
  - **Tooling impact -** None.
  - **Client tests -** Verified via psql/sqlcmd (`CAST(0x... AS sys.geometry)`); covered by existing JDBC/.NET/ODBC spatial multi-driver tests.

  ## Check List

  - [ ] Commits are signed per the DCO using --signoff

  By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of
  the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the
  PostgreSQL open source project.

  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
