### PR TITLE
fix: Add range validation in DATE to DATETIME2 cast (#4799)

### DIFF
--- a/contrib/babelfishpg_common/src/datetime2.c
+++ b/contrib/babelfishpg_common/src/datetime2.c
@@ -9,6 +9,7 @@
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "common/int.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
 #include "utils/datetime.h"
@@ -491,7 +492,22 @@ date_datetime2(PG_FUNCTION_ARGS)
 	else if (DATE_IS_NOEND(dateVal))
 		TIMESTAMP_NOEND(result);
 	else
-		result = dateVal * USECS_PER_DAY;
+	{
+		/*
+		 * Use overflow-safe multiplication to prevent int64 overflow.
+		 * dateVal * USECS_PER_DAY can overflow for dates outside the
+		 * valid datetime2 range (0001-01-01 to 9999-12-31).
+		 */
+		int64		product;
+
+		if (pg_mul_s64_overflow((int64) dateVal, USECS_PER_DAY, &product) ||
+			!IS_VALID_DATETIME2(product))
+			ereport(ERROR,
+					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+					 errmsg("data out of range for datetime2")));
+
+		result = (Timestamp) product;
+	}
 
 	PG_RETURN_TIMESTAMP(result);
 }

--- a/test/JDBC/expected/cast_date_to_datetime2.out
+++ b/test/JDBC/expected/cast_date_to_datetime2.out
@@ -1,0 +1,49 @@
+
+-- Test DATE to DATETIME2 cast with out-of-range dates (BABEL-4527)
+-- Out-of-range: year 999999 (exceeds datetime2 max of 9999-12-31)
+SELECT CAST(CAST('999999-12-31' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data out of range for datetime2)~~
+
+
+-- Out-of-range: year 10000 (just past valid range)
+SELECT CAST(CAST('10000-01-01' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data out of range for datetime2)~~
+
+
+-- Valid boundary: max datetime2 date
+SELECT CAST(CAST('9999-12-31' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+9999-12-31 00:00:00.0000000
+~~END~~
+
+
+-- Out-of-range: date before datetime2 min (PostgreSQL min date, 4714-11-24 BC)
+SELECT CAST(CAST('4714-11-24 BC' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: data out of range for datetime2)~~
+
+
+-- Valid boundary: min datetime2 date
+SELECT CAST(CAST('0001-01-01' AS DATE) AS datetime2);
+GO
+~~START~~
+datetime2
+0001-01-01 00:00:00.0000000
+~~END~~
+

--- a/test/JDBC/input/cast_date_to_datetime2.sql
+++ b/test/JDBC/input/cast_date_to_datetime2.sql
@@ -1,0 +1,21 @@
+-- Test DATE to DATETIME2 cast with out-of-range dates (BABEL-4527)
+
+-- Out-of-range: year 999999 (exceeds datetime2 max of 9999-12-31)
+SELECT CAST(CAST('999999-12-31' AS DATE) AS datetime2);
+GO
+
+-- Out-of-range: year 10000 (just past valid range)
+SELECT CAST(CAST('10000-01-01' AS DATE) AS datetime2);
+GO
+
+-- Valid boundary: max datetime2 date
+SELECT CAST(CAST('9999-12-31' AS DATE) AS datetime2);
+GO
+
+-- Out-of-range: date before datetime2 min (PostgreSQL min date, 4714-11-24 BC)
+SELECT CAST(CAST('4714-11-24 BC' AS DATE) AS datetime2);
+GO
+
+-- Valid boundary: min datetime2 date
+SELECT CAST(CAST('0001-01-01' AS DATE) AS datetime2);
+GO


### PR DESCRIPTION
CAST(DATE AS DATETIME2) hangs for dates outside the valid datetime2 range (0001-01-01 to 9999-12-31) because the multiplication dateVal * USECS_PER_DAY overflows int64.

Add a pre-multiplication bounds check in date_datetime2() to raise 'data out of range for datetime2' for out-of-range input dates.

Task: BABEL-4527

### Description

[Describe what this change achieves - Guidelines below (please delete the guidelines after writing the PR description)]

> 1. *What* is the change? This is best described in terms of “Currently, Babelfish does X. With this change it now does Y.” Think of “What *did* it *used* to do?” and “What *does* it do *now*?”
2. *Why* was the change made? What drove our desire to put effort into the change?
3. *How* was the code changed should only appear for large commits. This can serve as a rough roadmap to what’s contained in the commit. It should be very high level; if it’s directly referencing code it’s probably too detailed. It’s also critical that this section of a commit message does not try to replace proper code documentation (ie, block comments or README files). Generally, this section should only appear if the commit itself is large enough that it’s helpful to provide a roadmap to someone looking at the commit.
4. The last descriptive piece is the “title” for the commit: the very first line of the commit message, which should typically be less than 80 characters. A good title is *critical*, because it’s the only thing that shows up in places like the Github commit listing. No one’s got time to read through full commit messages when trying to find a single commit out of dozens.


### Issues Resolved

[List any issues this PR will resolve]

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).