### PR TITLE
[Insert Exec Redesign] Remove legacy tuple-store INSERT EXEC path

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsresponse.c
@@ -2708,10 +2708,10 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 				ListCell   *l;
 				PLtsql_expr *expr = ((PLtsql_stmt_execsql *) stmt)->sqlstmt;
 
-				/* True if running inside a new-path INSERT EXEC. */
+				/* True if this statement runs inside an INSERT EXEC. */
 				bool insert_exec_active =
-					(pltsql_plugin_handler_ptr->pltsql_insert_exec_active &&
-					 pltsql_plugin_handler_ptr->pltsql_insert_exec_active());
+					pltsql_plugin_handler_ptr->pltsql_insert_exec_active &&
+					pltsql_plugin_handler_ptr->pltsql_insert_exec_active();
 
 				/*
 				 * XXX: Once an error occurs, the expr and expr->plan may be
@@ -2736,21 +2736,17 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 								 * or if the INSERT itself is an INSERT-EXEC
 								 * and it just returned error.
 								 */
-								row_count_valid =
-									!estate->insert_exec &&
-									!insert_exec_active &&
-									!(markErrorFlag &&
-									  ((PLtsql_stmt_execsql *) stmt)->insert_exec);
+								row_count_valid = !insert_exec_active;
 							}
 							else if (plansource->commandTag == CMDTAG_UPDATE)
 							{
 								command_type = TDS_CMD_UPDATE;
-								row_count_valid = !estate->insert_exec && !insert_exec_active;
+								row_count_valid = !insert_exec_active;
 							}
 							else if (plansource->commandTag == CMDTAG_DELETE)
 							{
 								command_type = TDS_CMD_DELETE;
-								row_count_valid = !estate->insert_exec && !insert_exec_active;
+								row_count_valid = !insert_exec_active;
 							}
 
 							/*
@@ -2760,7 +2756,7 @@ StatementEnd_Internal(PLtsql_execstate *estate, PLtsql_stmt *stmt, bool error)
 							else if (plansource->commandTag == CMDTAG_SELECT)
 							{
 								command_type = TDS_CMD_SELECT;
-								row_count_valid = !estate->insert_exec && !insert_exec_active;
+								row_count_valid = !insert_exec_active;
 							}
 						}
 					}

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-decl.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-decl.y
@@ -50,7 +50,7 @@
 %type <fun_param> tsql_proc_arg tsql_func_arg
 %type <list> tsql_proc_args_list tsql_func_args_list
 
-%type <node> tsql_ExecStmt tsql_output_ExecStmt
+%type <node> tsql_ExecStmt
 %type <list> tsql_actual_args
 %type <list> tsql_opt_partition_scheme_or_filegroup
 %type <node> tsql_actual_arg

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2384,13 +2384,6 @@ tsql_output_insert_rest:
 					s->sortClause = $3;
 					$$->selectStmt = (Node*) s;
                 }
-			| tsql_ExecStmt
-                  {
-                      $$ = makeNode(InsertStmt);
-                      $$->cols = NIL;
-                      $$->selectStmt = NULL;
-                      $$->execStmt = $1;
-                  }
         ;
 
 tsql_output_insert_rest_no_paren:
@@ -2400,13 +2393,6 @@ tsql_output_insert_rest_no_paren:
                     $$->cols = NIL;
                     $$->selectStmt = $1;
                 }
-			| tsql_output_ExecStmt
-                  {
-                      $$ = makeNode(InsertStmt);
-                      $$->cols = NIL;
-                      $$->selectStmt = NULL;
-                      $$->execStmt = $1;
-                  }
 		;
 
 tsql_output_simple_select:
@@ -2585,34 +2571,6 @@ tsql_output_target_el: /* same as target_el but BareColLabel is not allowed. kee
 
 tsql_output_into_target_columns:
 					'(' insert_column_list ')'						{ $$ = $2; }
-		;
-
-tsql_output_ExecStmt:
-			TSQL_EXEC tsql_opt_return tsql_func_name tsql_actual_args
-				{
-					List *name = $3;
-					List *args = $4;
-					CallStmt *n;
-					ListCell *lc;
-
-					foreach(lc, args)
-					{
-						Node *node = lfirst(lc);
-						if (node->type == T_RowExpr)
-						{
-							RowExpr *row_expr = (RowExpr *) node;
-							ereport(ERROR,
-									(errcode(ERRCODE_SYNTAX_ERROR),
-									 errmsg("Row Expression argument not supported"),
-									 parser_errposition(row_expr->location)));
-						}
-					}
-
-					n = makeNode(CallStmt);
-					n->funccall = makeFuncCall(name, args, COERCE_EXPLICIT_CALL, @1);
-
-					$$ = (Node *) n;
-				}
 		;
 
 /* END rules for OUTPUT clause support */
@@ -2863,7 +2821,6 @@ tsql_InsertStmt:
 					i->withClause = $1;
 					i->cols = NIL;
 					i->selectStmt = NULL;
-					i->execStmt = NULL;
 					$$ = (Node *) i;
 				}
 			/* OUTPUT syntax */
@@ -2871,11 +2828,6 @@ tsql_InsertStmt:
 			 tsql_output_clause tsql_output_insert_rest_no_paren 
 				{
 					SelectLimit *top_stmt = (SelectLimit *)$3;
-					if ($11->execStmt)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
-								 parser_errposition(@10)));
 					$11->limitCount = top_stmt->limitCount;
 					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
 					$11->relation = $5;
@@ -2888,11 +2840,6 @@ tsql_InsertStmt:
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause tsql_output_insert_rest_no_paren 
 				{
 					SelectLimit *top_stmt = (SelectLimit *)$3;
-					if ($8->execStmt)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
-								 parser_errposition(@7)));
 					
 					$8->limitCount = top_stmt->limitCount;
 					tsql_check_top_percent_support(top_stmt, "INSERT", @3, yyscanner);
@@ -2916,7 +2863,6 @@ tsql_InsertStmt:
 					i->withClause = $1;
 					i->cols = NIL;
 					i->selectStmt = NULL;
-					i->execStmt = NULL;
 					$$ = (Node *) i;
 				}
 			*/
@@ -2924,22 +2870,12 @@ tsql_InsertStmt:
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
 			tsql_output_clause INTO insert_target tsql_output_into_target_columns tsql_output_insert_rest
 				{
-					if ($14->execStmt)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
-								 parser_errposition(@14)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, $13, $14, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, ((ReturningClause *) $10)->exprs, $12, $13, $14, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_into_target_columns tsql_output_insert_rest
 				{
-					if ($11->execStmt)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
-								 parser_errposition(@10)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, $11, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, ((ReturningClause *) $7)->exprs, $9, $10, $11, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_into_target_columns DEFAULT VALUES
@@ -2951,29 +2887,18 @@ tsql_InsertStmt:
 					i->withClause = NULL;
 					i->cols = NIL;
 					i->selectStmt = NULL;
-					i->execStmt = NULL;
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, i, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, ((ReturningClause *) $7)->exprs, $9, $10, i, 5, yyscanner);
 				}
 			/* Without OUTPUT target column list */
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
 			tsql_output_clause INTO insert_target tsql_output_insert_rest_no_paren
 				{
-					if ($13->execStmt)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
-								 parser_errposition(@13)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, NIL, $13, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, ((ReturningClause *) $10)->exprs, $12, NIL, $13, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_insert_rest_no_paren
 				{
-					if ($10->execStmt)
-						ereport(ERROR,
-								(errcode(ERRCODE_SYNTAX_ERROR),
-								 errmsg("The OUTPUT clause cannot be used in an INSERT...EXEC statement."),
-								 parser_errposition(@9)));
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, $10, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, ((ReturningClause *) $7)->exprs, $9, NIL, $10, 5, yyscanner);
 				}
 			/*
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
@@ -2986,7 +2911,6 @@ tsql_InsertStmt:
 					i->withClause = NULL;
 					i->cols = NIL;
 					i->selectStmt = NULL;
-					i->execStmt = NULL;
 					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, i, 5, yyscanner);
 				}
 			*/

--- a/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
+++ b/contrib/babelfishpg_tsql/src/backend_parser/gram-tsql-rule.y
@@ -2870,12 +2870,12 @@ tsql_InsertStmt:
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
 			tsql_output_clause INTO insert_target tsql_output_into_target_columns tsql_output_insert_rest
 				{
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, ((ReturningClause *) $10)->exprs, $12, $13, $14, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, $13, $14, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_into_target_columns tsql_output_insert_rest
 				{
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, ((ReturningClause *) $7)->exprs, $9, $10, $11, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, $11, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_into_target_columns DEFAULT VALUES
@@ -2887,18 +2887,18 @@ tsql_InsertStmt:
 					i->withClause = NULL;
 					i->cols = NIL;
 					i->selectStmt = NULL;
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, ((ReturningClause *) $7)->exprs, $9, $10, i, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, $10, i, 5, yyscanner);
 				}
 			/* Without OUTPUT target column list */
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr '(' insert_column_list ')'
 			tsql_output_clause INTO insert_target tsql_output_insert_rest_no_paren
 				{
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, ((ReturningClause *) $10)->exprs, $12, NIL, $13, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, $8, $10, $12, NIL, $13, 5, yyscanner);
 				}
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 
 			INTO insert_target tsql_output_insert_rest_no_paren
 				{
-					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, ((ReturningClause *) $7)->exprs, $9, NIL, $10, 5, yyscanner);
+					$$ = tsql_insert_output_into_cte_transformation($1, $3, $5, NULL, $7, $9, NIL, $10, 5, yyscanner);
 				}
 			/*
 			| opt_with_clause INSERT opt_top_clause tsql_opt_INTO insert_target tsql_opt_table_hint_expr tsql_output_clause 

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -58,7 +58,6 @@ bool		pltsql_disable_batch_auto_commit = false;
 bool		pltsql_disable_internal_savepoint = false;
 bool		pltsql_disable_txn_in_triggers = false;
 bool		pltsql_recursive_triggers = false;
-bool		pltsql_enable_new_insert_exec = true;
 bool		pltsql_noexec = false;
 bool		pltsql_showplan_all = false;
 bool		pltsql_showplan_text = false;
@@ -949,15 +948,6 @@ define_custom_variables(void)
 							 &pltsql_recursive_triggers,
 							 false,
 							 PGC_USERSET,
-							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
-							 NULL, NULL, NULL);
-
-	DefineCustomBoolVariable("babelfishpg_tsql.enable_new_insert_exec",
-							 gettext_noop("Enables INSERT...EXEC redesign code path"),
-							 NULL,
-							 &pltsql_enable_new_insert_exec,
-							 true,
-							 PGC_SUSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
 							 NULL, NULL, NULL);
 

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -34,7 +34,6 @@ extern bool pltsql_allow_windows_login;
 extern bool pltsql_allow_fulltext_parser;
 extern bool pltsql_weak_view_binding;
 extern bool pltsql_no_browsetable;
-extern bool pltsql_enable_new_insert_exec;
 extern char *pltsql_psql_logical_babelfish_db_name;
 extern int  pltsql_isolation_level_repeatable_read;
 extern int  pltsql_isolation_level_serializable;

--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -245,7 +245,6 @@ static void pltsql_ExecUpdateResultTypeTL(PlanState *planstate, TupleDesc desc);
 static bool plsql_TriggerRecursiveCheck(ResultRelInfo *resultRelInfo);
 static bool bbf_check_rowcount_hook(int es_processed);
 
-extern bool called_from_tsql_insert_exec();
 extern bool called_for_tsql_itvf_func();
 static void is_function_pg_stat_valid(FunctionCallInfo fcinfo,
 									  PgStat_FunctionCallUsage *fcu,
@@ -380,7 +379,6 @@ static bbf_get_sysadmin_oid_hook_type prev_bbf_get_sysadmin_oid_hook = NULL;
 static get_bbf_admin_oid_hook_type prev_get_bbf_admin_oid_hook = NULL;
 static transform_pivot_clause_hook_type pre_transform_pivot_clause_hook = NULL;
 static transform_tsql_select_stmt_hook_type pre_transform_tsql_select_stmt_hook = NULL;
-static called_from_tsql_insert_exec_hook_type pre_called_from_tsql_insert_exec_hook = NULL;
 static called_for_tsql_itvf_func_hook_type prev_called_for_tsql_itvf_func_hook = NULL;
 static exec_tsql_cast_value_hook_type pre_exec_tsql_cast_value_hook = NULL;
 static pltsql_pgstat_end_function_usage_hook_type prev_pltsql_pgstat_end_function_usage_hook = NULL;
@@ -607,9 +605,6 @@ InstallExtendedHooks(void)
 	prev_optimize_explicit_cast_hook = optimize_explicit_cast_hook;
 	optimize_explicit_cast_hook = optimize_explicit_cast;
 
-	pre_called_from_tsql_insert_exec_hook = called_from_tsql_insert_exec_hook;
-	called_from_tsql_insert_exec_hook = called_from_tsql_insert_exec;
-
 	prev_called_for_tsql_itvf_func_hook = called_for_tsql_itvf_func_hook;
 	called_for_tsql_itvf_func_hook = called_for_tsql_itvf_func;
 
@@ -745,7 +740,6 @@ UninstallExtendedHooks(void)
 	transform_pivot_clause_hook = pre_transform_pivot_clause_hook;
 	transform_tsql_select_stmt_hook = pre_transform_tsql_select_stmt_hook;
 	optimize_explicit_cast_hook = prev_optimize_explicit_cast_hook;
-	called_from_tsql_insert_exec_hook = pre_called_from_tsql_insert_exec_hook;
 	called_for_tsql_itvf_func_hook = prev_called_for_tsql_itvf_func_hook;
 	pltsql_pgstat_end_function_usage_hook = prev_pltsql_pgstat_end_function_usage_hook;
 	pltsql_unique_constraint_nulls_ordering_hook = prev_pltsql_unique_constraint_nulls_ordering_hook;

--- a/contrib/babelfishpg_tsql/src/iterative_exec.c
+++ b/contrib/babelfishpg_tsql/src/iterative_exec.c
@@ -1035,7 +1035,7 @@ is_batch_command(PLtsql_stmt *stmt)
 		case PLTSQL_STMT_EXEC_SP:
 			return true;
 		case PLTSQL_STMT_EXECSQL:
-			return ((PLtsql_stmt_execsql *) stmt)->insert_exec;
+			return false;
 		default:
 			return false;
 	}

--- a/contrib/babelfishpg_tsql/src/multidb.c
+++ b/contrib/babelfishpg_tsql/src/multidb.c
@@ -89,16 +89,6 @@ rewrite_object_refs(Node *stmt)
 		case T_DeleteStmt:
 		case T_InsertStmt:
 			{
-				/*
-				 * For INSERT ... EXECUTE, rewrite the schema name
-				*/
-				if ((nodeTag(stmt) == T_InsertStmt && ((InsertStmt *)stmt)->execStmt)
-					&& nodeTag(((InsertStmt *)stmt)->execStmt) == T_CallStmt)
-				{
-					CallStmt   *call = (CallStmt *) ((InsertStmt *)stmt)->execStmt;
-					call->funccall->funcname = rewrite_plain_name(call->funccall->funcname);
-				}
-
 				/* walker supported stmts */
 				raw_expression_tree_walker(stmt,
 										   rewrite_relation_walker,

--- a/contrib/babelfishpg_tsql/src/pl_exec-2.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec-2.c
@@ -70,7 +70,6 @@ static int	exec_stmt_fulltextindex(PLtsql_execstate *estate, PLtsql_stmt_fulltex
 static int	exec_stmt_grantschema(PLtsql_execstate *estate, PLtsql_stmt_grantschema *stmt);
 static int	exec_stmt_partition_function(PLtsql_execstate *estate, PLtsql_stmt_partition_function *stmt);
 static int	exec_stmt_partition_scheme(PLtsql_execstate *estate, PLtsql_stmt_partition_scheme *stmt);
-static int	exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *expr);
 static int	exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *expr);
 static int	exec_stmt_dbcc(PLtsql_execstate *estate, PLtsql_stmt_dbcc *stmt);
 extern Datum pltsql_inline_handler(PG_FUNCTION_ARGS);
@@ -82,7 +81,6 @@ static bool is_char_identstart(char c);
 static bool is_char_identpart(char c);
 
 void		read_param_def(InlineCodeBlockArgs *args, const char *paramdefstr);
-bool  		called_from_tsql_insert_exec(void);
 void		cache_inline_args(PLtsql_function *func, InlineCodeBlockArgs *args);
 InlineCodeBlockArgs *create_args(int numargs);
 InlineCodeBlockArgs *clone_inline_args(InlineCodeBlockArgs *args);
@@ -122,7 +120,6 @@ extern SPIPlanPtr prepare_stmt_exec(PLtsql_execstate *estate, PLtsql_function *f
 extern int	sp_prepare_count;
 
 BulkCopyStmt *cstmt = NULL;
-bool		called_from_tsql_insert_execute = false;
 
 int			insert_bulk_rows_per_batch = DEFAULT_INSERT_BULK_ROWS_PER_BATCH;
 int			insert_bulk_kilobytes_per_batch = DEFAULT_INSERT_BULK_PACKET_SIZE;
@@ -743,20 +740,15 @@ exec_stmt_push_result(PLtsql_execstate *estate,
 
 	Assert(stmt->query != NULL);
 
-	/* Handle naked SELECT stmt differently for INSERT ... EXECUTE (legacy path). */
-	if (estate->insert_exec)
-		return exec_stmt_insert_execute_select(estate, stmt->query);
-
 	exec_run_select(estate, stmt->query, &portal);
 
 	/*
-	 * When INSERT EXEC is active (new path), redirect results to the temp
-	 * table instead of sending to client.
+	 * When INSERT EXEC is active, redirect results to the temp table
+	 * instead of sending to client.
 	 */
 	if (pltsql_insert_exec_active())
 	{
 		receiver = CreateInsertExecDestReceiver();
-		receiver->rStartup(receiver, CMD_SELECT, portal->tupDesc);
 	}
 	else
 	{
@@ -816,7 +808,6 @@ exec_run_dml_with_output(PLtsql_execstate *estate, PLtsql_stmt_push_result *stmt
 	if (pltsql_insert_exec_active())
 	{
 		receiver = CreateInsertExecDestReceiver();
-		receiver->rStartup(receiver, CMD_SELECT, portal->tupDesc);
 	}
 	else
 	{
@@ -892,13 +883,9 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 		int32		rettypmod;	/* used for scalar function */
 		bool		is_scalar_func;
 
-		/* for EXEC as part of inline code under INSERT ... EXECUTE (legacy path) */
-		Tuplestorestate *tss;
-		DestReceiver *dest;
-
 		/*
-		 * Setup INSERT EXEC (new path): create temp table to capture procedure
-		 * output. After procedure completes, temp table is flushed to target.
+		 * Setup INSERT EXEC: create temp table to capture procedure output.
+		 * After procedure completes, temp table is flushed to target.
 		 */
 		if (stmt->insert_exec != NULL)
 			insert_exec_setup(estate, stmt->insert_exec, true);
@@ -1193,38 +1180,6 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 			stmt->target = (PLtsql_variable *) row;
 		}
 
-		if (estate->insert_exec)
-		{
-			/*
-			 * For EXEC under INSERT ... EXECUTE, get the expected TupleDesc,
-			 * create a DestReceiver and pass both to the CallStmt so that it
-			 * will know to accumulate result rows and send them back here.
-			 * Note : Legacy codepath for insert-exec, remove it during cleanup.
-			 */
-
-			Node	   *node;
-			CallStmt   *callstmt;
-
-			/*
-			 * Get the parsed CallStmt
-			 */
-			node = linitial_node(Query,
-								 ((CachedPlanSource *) linitial(plan->plancache_list))->query_list)->utilityStmt;
-			if (node == NULL || !IsA(node, CallStmt))
-				elog(ERROR, "query for CALL statement is not a CallStmt");
-
-			tss = tuplestore_begin_heap(false, false, work_mem);
-			dest = CreateTuplestoreDestReceiver();
-			SetTuplestoreDestReceiverParams(dest, tss, CurrentMemoryContext, false, NULL, NULL);
-			dest->rStartup(dest, -1, estate->rsi->expectedDesc);
-
-			callstmt = (CallStmt *) node;
-			callstmt->relation = InvalidOid;
-			callstmt->attrnos = NULL;
-			callstmt->retdesc = (void *) estate->rsi->expectedDesc;
-			callstmt->dest = (void *) dest;
-		}
-
 		paramLI = setup_param_list(estate, expr);
 
 		before_lxid = MyProc->vxid.lxid;
@@ -1283,34 +1238,6 @@ exec_stmt_exec(PLtsql_execstate *estate, PLtsql_stmt_exec *stmt)
 			{
 				exec_assign_value(estate, (PLtsql_datum *) return_code, Int32GetDatum(pltsql_proc_return_code), false, INT4OID, 0);
 			}
-		}
-
-		if (estate->insert_exec)
-		{
-			/*
-			 * For EXEC under INSERT ... EXECUTE, get the rows sent back by
-			 * the CallStmt, and store them into estate->tuple_store so that
-			 * at the end of function execution they will be sent to the right
-			 * place.
-			 * Note : Legacy insert-exec codepath, needs to remove during cleanup.
-			 */
-			TupleTableSlot *slot = MakeSingleTupleTableSlot(estate->rsi->expectedDesc,
-															&TTSOpsMinimalTuple);
-
-			if (estate->tuple_store == NULL)
-				exec_init_tuple_store(estate);
-
-			for (;;)
-			{
-				if (!tuplestore_gettupleslot(tss, true, false, slot))
-					break;
-				tuplestore_puttupleslot(estate->tuple_store, slot);
-				ExecClearTuple(slot);
-			}
-			ExecDropSingleTupleTableSlot(slot);
-
-			dest->rShutdown(dest);
-			dest->rDestroy(dest);
 		}
 
 		if (rc < 0)
@@ -2267,10 +2194,11 @@ exec_stmt_exec_sp(PLtsql_execstate *estate, PLtsql_stmt_exec_sp *stmt)
 				PG_TRY();
 				{
 					/*
-					 * INSERT EXEC handling (new path):
-					 * If this is an INSERT EXEC statement (set by parser), create temp table here.
-					 * The procedure output will be redirected to this temp table.
-					 * After procedure completes, we flush temp table to target and cleanup.
+					 * INSERT EXEC handling: if this is an INSERT EXEC statement
+					 * (set by parser), create temp table here.  The procedure
+					 * output will be redirected to this temp table.  After the
+					 * procedure completes, we flush the temp table to the target
+					 * and cleanup.
 					 */
 					if (stmt->insert_exec != NULL)
 						insert_exec_setup(estate, stmt->insert_exec, true);
@@ -3287,82 +3215,6 @@ exec_stmt_grantdb(PLtsql_execstate *estate, PLtsql_stmt_grantdb *stmt)
 	return PLTSQL_RC_OK;
 }
 
-bool called_from_tsql_insert_exec()
-{
-	if (sql_dialect != SQL_DIALECT_TSQL)
-		return false;
-	return called_from_tsql_insert_execute;
-}
-
-/*
- * For naked SELECT stmt in INSERT ... EXECUTE, instead of pushing the result to
- * the client, we accumulate the result in estate->tuple_store (similar to
- * exec_stmt_return_query). Finally the EXECUTE stmt will return the result to
- * the INSERT stmt as rows to insert.
- * Note : Used by the legacy INSERT EXEC path, needs to remove during cleanup.
- */
-static int
-exec_stmt_insert_execute_select(PLtsql_execstate *estate, PLtsql_expr *query)
-{
-	Portal		portal;
-	uint64		processed = 0;
-	TupleConversionMap *tupmap;
-	MemoryContext oldcontext;
-
-	if (estate->tuple_store == NULL)
-		exec_init_tuple_store(estate);
-
-	Assert(query != NULL);
-	exec_run_select(estate, query, &portal);
-
-	/* Use eval_mcontext for tuple conversion work */
-	oldcontext = MemoryContextSwitchTo(get_eval_mcontext(estate));
-
-	called_from_tsql_insert_execute = true;
-	tupmap = convert_tuples_by_position(portal->tupDesc,
-										estate->tuple_store_desc,
-										gettext_noop("structure of query does not match function result type"));
-	called_from_tsql_insert_execute = false;
-	while (true)
-	{
-		uint64		i;
-
-		SPI_cursor_fetch(portal, true, 50);
-
-		/* SPI will have changed CurrentMemoryContext */
-		MemoryContextSwitchTo(get_eval_mcontext(estate));
-
-		if (SPI_processed == 0)
-			break;
-
-		for (i = 0; i < SPI_processed; i++)
-		{
-			HeapTuple	tuple = SPI_tuptable->vals[i];
-
-			if (tupmap)
-			{
-				called_from_tsql_insert_execute = true;
-				tuple = execute_attr_map_tuple(tuple, tupmap);
-				called_from_tsql_insert_execute = false;
-			}
-			tuplestore_puttuple(estate->tuple_store, tuple);
-			if (tupmap)
-				heap_freetuple(tuple);
-			processed++;
-		}
-
-		SPI_freetuptable(SPI_tuptable);
-	}
-
-	SPI_freetuptable(SPI_tuptable);
-	SPI_cursor_close(portal);
-
-	MemoryContextSwitchTo(oldcontext);
-	exec_eval_cleanup(estate);
-
-	return PLTSQL_RC_OK;
-}
-
 int
 exec_stmt_insert_bulk(PLtsql_execstate *estate, PLtsql_stmt_insert_bulk *stmt)
 {
@@ -3908,11 +3760,10 @@ execute_plan_and_push_result(PLtsql_execstate *estate, PLtsql_expr *expr, ParamL
 	else if (pltsql_insert_exec_active())
 	{
 		/*
-		 * INSERT EXEC context is active (new path) - redirect results to temp
-		 * table instead of sending to client.
+		 * INSERT EXEC context is active redirect results to temp table
+		 * instead of sending to client.
 		 */
 		receiver = CreateInsertExecDestReceiver();
-		receiver->rStartup(receiver, CMD_SELECT, portal->tupDesc);
 	}
 	else
 	{

--- a/contrib/babelfishpg_tsql/src/pl_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_exec.c
@@ -74,9 +74,6 @@ static bool is_schemabinding_view = true;
 int			fetch_status_var = 0;
 int			saved_expr_kind = -1;
 
-/* Global variable to record the retval for insert exec */
-Datum execute_call_insert_exec_retval = (Datum) 0;
-
 typedef struct
 {
 	int			nargs;			/* number of arguments */
@@ -496,10 +493,6 @@ extern int
 static void
 pltsql_exec_function_cleanup(PLtsql_execstate *estate, PLtsql_function *func, ErrorContextCallback *plerrcontext);
 
-/* Function to set up row Datum for INSERT EXEC (legacy path) */
-static void
-setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt);
-
 static bool	called_for_tsql_itvf_function = false;
 bool  		called_for_tsql_itvf_func(void);
 
@@ -714,11 +707,8 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 
 		fcinfo->isnull = estate.retisnull;
 
-		if (estate.retisset || estate.insert_exec)
+		if (estate.retisset)
 		{
-			int16 typLen;
-			bool typByVal;
-			MemoryContext oldcontext;
 			ReturnSetInfo *rsi = estate.rsi;
 
 			/* Check caller can handle a set result */
@@ -738,53 +728,6 @@ pltsql_exec_function(PLtsql_function *func, FunctionCallInfo fcinfo,
 				oldcxt = MemoryContextSwitchTo(estate.tuple_store_cxt);
 				rsi->setDesc = CreateTupleDescCopy(estate.tuple_store_desc);
 				MemoryContextSwitchTo(oldcxt);
-			}
-
-			/*
-			 * Obtain output parameters for Insert Execute 
-			 * Note : It's insert-exec legacy codepath need to remove during cleanup.
-			 */
-			if (estate.insert_exec)
-			{
-				/* Switch to function's memory context */
-				oldcontext = MemoryContextSwitchTo(estate.func->fn_cxt);
-
-				if (OidIsValid(estate.rettype))
-				{
-					/* Get return type properties */
-					get_typlenbyval(estate.rettype, &typLen, &typByVal);
-
-					if (typByVal)
-					{
-						execute_call_insert_exec_retval = estate.retval;
-					}
-					else
-					{
-						/* Pass-by-reference, need to copy the data */
-						execute_call_insert_exec_retval = datumCopy(estate.retval,
-																	typByVal,
-																	typLen);
-					}
-				}
-				else
-				{
-					/* For cases where rettype is not properly set, handle gracefully */
-					typLen = -1;    /* Variable length */
-					typByVal = false; /* Pass by reference */
-					
-					/* Only proceed if we have a valid return value */
-					if (estate.retval != (Datum) 0)
-					{
-						execute_call_insert_exec_retval = estate.retval;
-					}
-					else
-					{
-						/* Skip the exec_move_row_from_datum call entirely */
-						execute_call_insert_exec_retval = (Datum) 0;
-					}
-				}
-				MemoryContextSwitchTo(oldcontext);
-
 			}
 
 			estate.retval = (Datum) 0;
@@ -4394,18 +4337,6 @@ pltsql_estate_setup(PLtsql_execstate *estate,
 
 	estate->nestlevel = -1;
 
-	/*
-	 * When executing a procedure or inline code block, if a ReturnSetInfo is
-	 * passed in, then it's invoked by INSERT ... EXECUTE.
-	 * Note : It's used by legacy insert-exec codepath, need to remove during cleanup.
-	 */
-	if (pltsql_enable_new_insert_exec)
-		estate->insert_exec = false;
-	else
-	estate->insert_exec = (func->fn_prokind == PROKIND_PROCEDURE ||
-						   strcmp(func->fn_signature, "inline_code_block") == 0)
-		&& rsi;
-	
 	estate->explain_infos = NIL;
 
 	/*
@@ -4667,147 +4598,6 @@ is_impl_txn_required_for_execsql(PLtsql_stmt_execsql *stmt)
 	return true;
 }
 
-/*
- * setup_procedure_output_target_for_insert_exec - Create output target for INSERT EXECUTE
- *
- * This is a helper to adapt logic from exec_stmt_call. It constructs a PLtsql_row to capture
- * output parameters from a procedure call within an INSERT EXECUTE context.
- * Used by the legacy INSERT EXEC path (GUC babelfishpg_tsql.enable_new_insert_exec = false).
- */
-static void
-setup_procedure_output_target_for_insert_exec(PLtsql_execstate *estate, PLtsql_stmt_execsql *stmt)
-{
-    CachedPlanSource *cachedPlanSource;
-    Node *node;
-    FuncExpr *funcexpr;
-    HeapTuple func_tuple;
-    List *funcargs;
-    Oid *argtypes;
-    char **argnames;
-    char *argmodes;
-    MemoryContext oldcontext;
-    PLtsql_row *row;
-    int nfields;
-    int i;
-    ListCell *lc;
-
-	/* Early NULL checks */
-	if (!stmt || !stmt->sqlstmt || !stmt->sqlstmt->plan || !stmt->sqlstmt->plan->plancache_list)
-		return; /* Not a procedure call */
-
-    /* Extract the CallStmt from the cached plan */
-    cachedPlanSource = (CachedPlanSource *) linitial(stmt->sqlstmt->plan->plancache_list);
-    node = linitial_node(Query, cachedPlanSource->query_list)->utilityStmt;
-
-    if (node == NULL || !IsA(node, CallStmt))
-        return; /* Not a procedure call */
-
-    funcexpr = ((CallStmt *) node)->funcexpr;
-
-    /* Look up the procedure in pg_proc */
-    func_tuple = SearchSysCache1(PROCOID, ObjectIdGetDatum(funcexpr->funcid));
-    if (!HeapTupleIsValid(func_tuple))
-        elog(ERROR, "cache lookup failed for function %u", funcexpr->funcid);
-
-    /* Extract function arguments, expanding any named-arg notation */
-    funcargs = expand_function_arguments(funcexpr->args,
-                                       false,
-                                       funcexpr->funcresulttype,
-                                       func_tuple);
-
-    /* Mark the procedure outside the view since procedure can never be called inside a view */
-    funcexpr->insideView = PNODE_OUTSIDE_VIEW;
-    /* Get the argument names and modes */
-    get_func_arg_info(func_tuple, &argtypes, &argnames, &argmodes);
-
-    ReleaseSysCache(func_tuple);
-
-    /*
-     * Begin constructing row Datum
-     */
-    oldcontext = MemoryContextSwitchTo(estate->func->fn_cxt);
-
-    row = makeNode(PLtsql_row);
-    row->dtype = PLTSQL_DTYPE_ROW;
-    row->refname = "(unnamed row)";
-    row->lineno = -1;
-    row->varnos = (int *) palloc(sizeof(int) * list_length(funcargs));
-
-    MemoryContextSwitchTo(oldcontext);
-
-    /*
-     * Examine procedure's argument list. Each output arg position
-     * should be an unadorned pltsql variable (Datum), which we can
-     * insert into the row Datum.
-     */
-    nfields = 0;
-    i = 0;
-    foreach(lc, funcargs)
-    {
-        Node *n = lfirst(lc);
-
-        if (argmodes &&
-            (argmodes[i] == PROARGMODE_INOUT ||
-             argmodes[i] == PROARGMODE_OUT))
-        {
-            if (IsA(n, Param))
-            {
-                Param *param = (Param *) n;
-
-                /* paramid is offset by 1 (see make_datum_param()) */
-                row->varnos[nfields++] = param->paramid - 1;
-            }
-            else if (get_underlying_node_from_implicit_casting(n, T_Param) != NULL)
-            {
-                /*
-                 * T-SQL allows implicit casting in INOUT and OUT params.
-                 * Strip the casting and get the underlying Param.
-                 */
-                Param *param = (Param *) get_underlying_node_from_implicit_casting(n, T_Param);
-
-                /* paramid is offset by 1 (see make_datum_param()) */
-                row->varnos[nfields++] = param->paramid - 1;
-            }
-            else if (argmodes[i] == PROARGMODE_INOUT && IsA(n, Const))
-            {
-                /*
-                 * T-SQL allows to pass constant value as an output parameter.
-                 * Put -1 to param id. We can skip assigning actual value.
-                 */
-                row->varnos[nfields++] = -1;
-            }
-            else if (argmodes[i] == PROARGMODE_INOUT && get_underlying_node_from_implicit_casting(n, T_Const) != NULL)
-            {
-                /*
-                 * Mixture case of implicit casting + CONST. We can
-                 * skip assigning actual value.
-                 */
-                row->varnos[nfields++] = -1;
-            }
-            else
-            {
-                /* report error using parameter name, if available */
-                if (argnames && argnames[i] && argnames[i][0])
-                    ereport(ERROR,
-                            (errcode(ERRCODE_SYNTAX_ERROR),
-                             errmsg("procedure parameter \"%s\" is an output parameter but corresponding argument is not writable",
-                                    argnames[i])));
-                else
-                    ereport(ERROR,
-                            (errcode(ERRCODE_SYNTAX_ERROR),
-                             errmsg("procedure parameter %d is an output parameter but corresponding argument is not writable",
-                                    i + 1)));
-            }
-        }
-        i++;
-    }
-
-    row->nfields = nfields;
-
-    stmt->target = (PLtsql_variable *) row;
-}
-
-
 /* ----------
  * exec_stmt_execsql			Execute an SQL statement (possibly with INTO).
  *
@@ -4851,19 +4641,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 
 	PG_TRY();
 	{
-		/* Handle naked SELECT stmt differently for INSERT ... EXECUTE */
-		if (stmt->need_to_push_result && estate->insert_exec)
-		{
-			int			ret = exec_stmt_insert_execute_select(estate, expr);
-
-			if (is_cross_db)
-			{
-				if (stmt->schema_name != NULL && (strcmp(stmt->schema_name, "sys") == 0 || strcmp(stmt->schema_name, "information_schema") == 0))
-					set_cur_user_db_and_path(cur_dbname, true);
-			}
-			return ret;
-		}
-
 		if (expr->plan && expr->plan->oneshot)
 		{
 			SPI_freeplan(expr->plan);
@@ -4891,38 +4668,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		 * Set up ParamListInfo to pass to executor
 		 */
 		paramLI = setup_param_list(estate, expr);
-
-		/*
-		 * Legacy INSERT EXEC path: nested-INSERT-EXEC check and output target
-		 * setup. estate->insert_exec / stmt->insert_exec are only set when the
-		 * new INSERT EXEC GUC is off.
-		 */
-		if (!pltsql_enable_new_insert_exec)
-		{
-			/* Check for nested INSERT EXECUTE statements */
-			if (stmt->insert_exec)
-			{
-				/* Walk existing stack for any parent insert exec */
-				PLExecStateCallStack *cur = exec_state_call_stack;
-				while (cur != NULL)
-				{
-					/* Found parent insert exec - this is a nested INSERT EXECUTE */
-					if (cur->estate->insert_exec)
-					{
-						ereport(ERROR,
-							(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
-							errmsg("nested INSERT ... EXECUTE statements are not allowed")));
-					}
-					cur = cur->next;
-				}
-			}
-
-			/* Setup output target for procedure parameters */
-			if (stmt->insert_exec && stmt->target == NULL)
-			{
-				setup_procedure_output_target_for_insert_exec(estate, stmt);
-			}
-		}
 
 		/*
 		 * Check whether the statement is an INSERT/DELETE with RETURNING
@@ -5106,16 +4851,6 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 				break;
 		}
 
-		/*
-		 * Update the output parameter
-		 * Note : It's insert-exec legacy codepath, need to remove during cleanup.
-		 */
-		if (!pltsql_enable_new_insert_exec &&
-			stmt->insert_exec && stmt->target && execute_call_insert_exec_retval != (Datum) 0)
-		{
-			exec_move_row_from_datum(estate, stmt->target, execute_call_insert_exec_retval);
-		}
-
 		if (enable_txn_in_triggers)
 		{
 			if (!stmt->need_to_push_result)
@@ -5268,17 +5003,13 @@ exec_stmt_execsql(PLtsql_execstate *estate,
 		 *
 		 * Also skip commit during INSERT EXEC or its flush phase to avoid
 		 * orphaning SPI portal snapshots.
-		 *
-		 * INSERT EXEC detection differs by path: the new path uses the global
-		 * context (pltsql_insert_exec_active), the legacy path uses the
-		 * per-estate flag (estate->insert_exec).
 		 */
 		/* TODO To let procedure call from PSQL work with old semantics */
 		if ((!pltsql_disable_batch_auto_commit || (stmt->txn_data != NULL)) &&
 			support_tsql_trans &&
 			(enable_txn_in_triggers || estate->trigdata == NULL) &&
 			!ro_func &&
-			!pltsql_insert_exec_active() && !estate->insert_exec)
+			!pltsql_insert_exec_active())
 		{
 			commit_stmt(estate, (estate->tsql_trigger_flags & TSQL_TRAN_STARTED));
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -6925,7 +6925,6 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 	FunctionCallInfo fake_fcinfo = palloc0(SizeForFunctionCallInfo(nargs));
 	bool		nonatomic;
 	bool		support_tsql_trans = pltsql_support_tsql_transactions();
-	ReturnSetInfo rsinfo;		/* for INSERT ... EXECUTE */
 
 	/*
 	 * FIXME: We leak sp_describe_first_result_set_inprogress if CREATE VIEW
@@ -7034,46 +7033,6 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 	else
 		simple_eval_estate = CreateExecutorState();
 
-	/*
-	 * If we are here for INSERT ... EXECUTE, prepare a resultinfo node for
-	 * communication before invoking the function, which can accumulate the
-	 * result sets.
-	 */
-	if (codeblock->relation && codeblock->attrnos)
-	{
-		Oid			reltypeid;
-		TupleDesc	reldesc;
-		TupleDesc	retdesc;
-		int			natts = 0;
-		ListCell   *lc;
-		ListCell   *next;
-
-		/* look up the INSERT target relation rowtype's tupdesc */
-		reltypeid = get_rel_type_id(codeblock->relation);
-		reldesc = lookup_rowtype_tupdesc(reltypeid, -1);
-
-		/* build a tupdesc that only contains relevant INSERT columns */
-		retdesc = CreateTemplateTupleDesc(list_length(codeblock->attrnos));
-		for (lc = list_head(codeblock->attrnos); lc != NULL; lc = next)
-		{
-			natts += 1;
-			TupleDescCopyEntry(retdesc, natts, reldesc, lfirst_int(lc));
-			next = lnext(codeblock->attrnos, lc);
-		}
-
-		fake_fcinfo->resultinfo = (Node *) &rsinfo;
-		rsinfo.type = T_ReturnSetInfo;
-		rsinfo.econtext = CreateExprContext(simple_eval_estate);
-		rsinfo.expectedDesc = retdesc;
-		rsinfo.allowedModes = (int) (SFRM_ValuePerCall | SFRM_Materialize);
-		/* note we do not set SFRM_Materialize_Random or _Preferred */
-		rsinfo.returnMode = SFRM_ValuePerCall;
-		rsinfo.isDone = ExprSingleResult;
-		rsinfo.setResult = NULL;
-		rsinfo.setDesc = NULL;
-		ReleaseTupleDesc(reldesc);
-	}
-
 	/* And run the function */
 	PG_TRY();
 	{
@@ -7119,28 +7078,6 @@ pltsql_inline_handler(PG_FUNCTION_ARGS)
 		return retval;
 	}
 	PG_END_TRY();
-
-	if (codeblock->dest && rsinfo.setDesc && rsinfo.setResult)
-	{
-		/*
-		 * If we are here for INSERT ... EXECUTE, send all tuples accumulated
-		 * in resultinfo to the DestReceiver, which will later be consumed by
-		 * the INSERT execution.
-		 */
-		TupleTableSlot *slot = MakeSingleTupleTableSlot(rsinfo.expectedDesc,
-														&TTSOpsMinimalTuple);
-		DestReceiver *dest = (DestReceiver *) codeblock->dest;
-
-		for (;;)
-		{
-			if (!tuplestore_gettupleslot(rsinfo.setResult, true, false, slot))
-				break;
-			dest->receiveSlot(slot, dest);
-			ExecClearTuple(slot);
-		}
-		ReleaseTupleDesc(rsinfo.expectedDesc);
-		ExecDropSingleTupleTableSlot(slot);
-	}
 
 	/* Function should now have no remaining use-counts ... */
 	func->use_count--;

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -61,6 +61,7 @@ typedef struct
 	ProjectionInfo *proj_info;	/* projection info for coercion */
 	TupleTableSlot *proj_slot;	/* result slot for projection */
 	CommandId	cid;			/* command ID obtained once in startup, shared across all tuples */
+	Relation	temp_rel;		/* temp buffer table, held open startup→shutdown */
 } DR_insertexec;
 
 /* Forward declarations for DestReceiver callbacks */
@@ -366,10 +367,10 @@ pltsql_insert_exec_validate_column_count(PLtsql_execstate *estate, PLtsql_stmt_e
 	query_natts = result_desc->natts;
 
 	/* Get temp table column count */
-	temp_rel = table_open(temp_table_oid, AccessShareLock);
+	temp_rel = table_open(temp_table_oid, NoLock);
 	temp_tupdesc = RelationGetDescr(temp_rel);
 	temp_natts = temp_tupdesc->natts;
-	table_close(temp_rel, AccessShareLock);
+	table_close(temp_rel, NoLock);
 
 	/* Done reading the shape; drop the throwaway plan. */
 	SPI_freeplan(plan);
@@ -492,6 +493,10 @@ create_insert_exec_temp_table(const char *target_table, const char *column_list,
 	 * Create the temp buffer table by selecting the desired columns
 	 * with no rows. PostgreSQL infers column types from the SELECT.
 	 * ON COMMIT DROP ensures automatic cleanup at transaction end.
+	 *
+	 * This CREATE TABLE goes through heap_create_with_catalog, which takes
+	 * AccessExclusiveLock on the new relation and holds it until end of transaction.
+	 * 
 	 */
 	initStringInfo(&create_stmt);
 	appendStringInfo(&create_stmt,
@@ -674,8 +679,13 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	if (!OidIsValid(insert_exec_ctx->temp_table_oid))
 		elog(ERROR, "INSERT EXEC failed due to missing temp table OID");
 
-	/* Open temp table to read schema only - closed before startup returns */
-	temp_rel = table_open(insert_exec_ctx->temp_table_oid, AccessShareLock);
+	/*
+	 * Open the temp buffer table once and hold it open until shutdown, so all
+	 * tuples of this result set are inserted through a single relation handle.
+	 */
+	temp_rel = table_open(insert_exec_ctx->temp_table_oid, NoLock);
+
+	myState->temp_rel = temp_rel;
 	temp_tupdesc = RelationGetDescr(temp_rel);
 	temp_natts = temp_tupdesc->natts;
 
@@ -732,12 +742,10 @@ insertexec_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	}
 
 	/*
-	 * Copy the temp table descriptor before closing temp_rel.
-	 * INSERT EXEC must not hold a relation handle open
-	 * across the procedure's internal subtransaction boundaries.
+	 * Copy the temp table descriptor for the projection result slot. The
+	 * relation itself stays open (in myState->temp_rel) for the inserts.
 	 */
 	proj_tupdesc = CreateTupleDescCopy(temp_tupdesc);
-	table_close(temp_rel, AccessShareLock);
 
 	/* Create expression context and projection info */
 	myState->econtext = CreateStandaloneExprContext();
@@ -770,13 +778,9 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 	DR_insertexec *myState = (DR_insertexec *) self;
 	TupleTableSlot *insert_slot;
 
-	Relation	temp_rel;
-
 	Assert(myState->proj_info != NULL);
 	Assert(myState->econtext != NULL);
-
-	/* Open temp table fresh for each tuple - avoids stale handles across subtransactions */
-	temp_rel = table_open(insert_exec_ctx->temp_table_oid, RowExclusiveLock);
+	Assert(myState->temp_rel != NULL);
 
 	/* Reset per-tuple memory context for expression evaluation */
 	ResetExprContext(myState->econtext);
@@ -788,13 +792,10 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 	insert_slot = ExecProject(myState->proj_info);
 
 	/* Insert the projected tuple */
-	table_tuple_insert(temp_rel, insert_slot, myState->cid, 0, NULL);
+	table_tuple_insert(myState->temp_rel, insert_slot, myState->cid, 0, NULL);
 
 	/* INSERT EXEC rows-affected count */
 	insert_exec_ctx->rows_processed++;
-
-	/* Close immediately - do not hold open across subtransaction boundaries */
-	table_close(temp_rel, RowExclusiveLock);
 
 	return true;
 }
@@ -802,7 +803,8 @@ insertexec_receive(TupleTableSlot *slot, DestReceiver *self)
 /*
  * insertexec_shutdown - executor end for INSERT EXEC receiver
  *
- * Clean up the expression context and projection slot used for type coercion.
+ * Clean up the expression context, projection slot, and close the temp buffer
+ * table opened in startup.
  */
 static void
 insertexec_shutdown(DestReceiver *self)
@@ -816,6 +818,10 @@ insertexec_shutdown(DestReceiver *self)
 	Assert(myState->econtext != NULL);
 	FreeExprContext(myState->econtext, true);
 	myState->econtext = NULL;
+
+	Assert(myState->temp_rel != NULL);
+	table_close(myState->temp_rel, NoLock);
+	myState->temp_rel = NULL;
 }
 
 /*
@@ -899,7 +905,7 @@ insert_exec_setup(PLtsql_execstate *estate,
 }
 
 /*
- * insert_exec_success_cleanup - Clean up INSERT EXEC after successful execution.
+ * insert_exec_flush_and_cleanup - Clean up INSERT EXEC after successful execution.
  *
  * Flushes temp table to target, resets context, and commits the implicit
  * transaction if one was started. The flush target name parts come from the

--- a/contrib/babelfishpg_tsql/src/pltsql.h
+++ b/contrib/babelfishpg_tsql/src/pltsql.h
@@ -1290,7 +1290,6 @@ typedef struct PLtsql_stmt_execsql
 	bool		need_to_push_result;	/* push result to client */
 	bool		is_tsql_select_assign_stmt; /* T-SQL SELECT-assign (i.e.
 											 * SELECT @a=1) */
-	bool		insert_exec;	/* INSERT-EXEC stmt? */
 	bool		is_cross_db;	/* cross database reference */
 	bool		is_ddl;			/* DDL statement? */
 	char	   *schema_name;	/* Schema specified */
@@ -1664,13 +1663,6 @@ typedef struct PLtsql_execstate
 	size_t		cur_err_ctx_idx;
 
 	int			tsql_trigger_flags;
-
-	/*
-	 * A same procedure can be invoked by either normal EXECUTE or INSERT ...
-	 * EXECUTE, and can behave differently.
-	 * Note : It's Used insert-exec legacy codepath, need to remove during cleanup.
-	 */
-	bool		insert_exec;
 
 	List	   *explain_infos;
 	instr_time	planning_start;

--- a/contrib/babelfishpg_tsql/src/pltsql_utils.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_utils.c
@@ -83,14 +83,7 @@ const uint64 PLTSQL_LOCKTAG_OFFSET = 0xABCDEF;
 static void
 error_if_xact_stmt_blocked_by_insert_exec(bool is_commit)
 {
-	bool		in_insert_exec;
-
-	in_insert_exec = pltsql_insert_exec_active() ||
-		(exec_state_call_stack &&
-		 exec_state_call_stack->estate &&
-		 exec_state_call_stack->estate->insert_exec);
-
-	if (!in_insert_exec)
+	if (!pltsql_insert_exec_active())
 		return;
 
 	if (is_commit)

--- a/contrib/babelfishpg_tsql/src/tsqlIface.cpp
+++ b/contrib/babelfishpg_tsql/src/tsqlIface.cpp
@@ -2223,53 +2223,19 @@ public:
 			ctx->insert_statement()->insert_statement_value()->execute_statement();
 
 		/*
-		 * New INSERT EXEC code path - gated behind GUC pltsql_enable_new_insert_exec.
-		 * When enabled, we create a PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
-		 * which allows the executor to handle INSERT EXEC with the new DestReceiver
-		 * and temp table approach. When disabled, fall through to legacy behavior.
+		 * For INSERT EXEC, build a PLtsql_stmt_exec node so the executor can capture
+		 * procedure output via a DestReceiver into a temp table.
 		 *
 		 * Note : process_execsql_remove_unsupported_tokens() populates rewritten_query_fragment
 		 * which apply_exec_expression_rewriting() inside handleInsertExec() depends on.
-		 * Moving the check above it would break expression rewriting. 
+		 * Moving the check above it would break expression rewriting.
 		 */
-		if (is_insert_exec && pltsql_enable_new_insert_exec)
+		if (is_insert_exec)
 		{
 			handleInsertExec(ctx);
 			clear_query_hints();
 			clear_tables_info();
 			return;
-		}
-		/*
-		 * LEGACY INSERT EXEC CODE PATH (GUC pltsql_enable_new_insert_exec = false)
-		 * This code is only needed when the new INSERT EXEC implementation is disabled.
-		 * When the GUC is true, we use PLtsql_stmt_exec instead of PLtsql_stmt_execsql,
-		 * and the cross-database handling is done differently.
-		 * TODO: Remove this block when the new INSERT EXEC implementation is stable
-		 * and the GUC default is flipped to true.
-		 */
-		stmt->insert_exec = is_insert_exec;
-
-		/* Extract db_name and schema_name for cross-database INSERT EXEC (legacy path only) */
-		if (is_insert_exec)
-		{
-			TSqlParser::Func_proc_name_server_database_schemaContext *ctx_name = nullptr;
-			TSqlParser::Execute_bodyContext *body = nullptr;
-
-			TSqlParser::Execute_statementContext *ctxES = ctx->insert_statement()->insert_statement_value()->execute_statement();
-			body = ctxES->execute_body();
-			Assert(body);
-			
-			ctx_name       = body->func_proc_name_server_database_schema();
-			if (ctx_name) 
-			{				
-				if (ctx_name->database)
-				{
-					db_name = stripQuoteFromId(ctx_name->database);
-					is_cross_db = true;
-				}
-				if (ctx_name->schema)
-					schema_name = stripQuoteFromId(ctx_name->schema);
-			}
 		}
 
 		// record whether stmt is cross-db
@@ -2295,18 +2261,14 @@ public:
 			if (ctx->insert_statement())
 			{
 				auto ddl_object = ctx->insert_statement()->ddl_object();
-				if (stmt->insert_exec && ddl_object && !ddl_object->local_id()) /* insert into non-local object */
+				if (ddl_object && !ddl_object->local_id()) /* insert into non-local object */
 				{
-					throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT EXEC' cannot be used within a function", getLineAndPos(ddl_object));
-				}
-				else if (ddl_object && !ddl_object->local_id()) /* insert into non-local object */
-				{					
-					if (ddl_object && ddl_object->full_object_name() && isDelimitedAtAtUserVarName(getFullText(ddl_object->full_object_name()) ))
+					if (ddl_object->full_object_name() && isDelimitedAtAtUserVarName(getFullText(ddl_object->full_object_name())))
 					{
 						/* This is a table variable name enclosed in delimiters, which is OK */
 					}
-					else 
-						throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT' cannot be used within a function", getLineAndPos(ddl_object));					
+					else
+						throw PGErrorWrapperException(ERROR, ERRCODE_INVALID_FUNCTION_DEFINITION, "'INSERT' cannot be used within a function", getLineAndPos(ddl_object));
 				}
 			}
 			else if (ctx->update_statement() || ctx->delete_statement())
@@ -5268,7 +5230,6 @@ makeExecSql(ParserRuleContext *ctx)
 	stmt->target = NULL;
 	stmt->need_to_push_result = false;
 	stmt->is_tsql_select_assign_stmt = false;
-	stmt->insert_exec = false;
 
 	return (PLtsql_stmt *) stmt;
 }
@@ -6332,7 +6293,6 @@ makeSetStatement(TSqlParser::Set_statementContext *ctx, tsqlBuilder &builder)
 			stmt->target = NULL;
 			stmt->need_to_push_result = false;
 			stmt->is_tsql_select_assign_stmt = false;
-			stmt->insert_exec = false;
 
 			attachPLtsql_fragment(ctx, (PLtsql_stmt *) stmt);
 			return (PLtsql_stmt *) stmt;
@@ -6386,7 +6346,6 @@ makeSetStatement(TSqlParser::Set_statementContext *ctx, tsqlBuilder &builder)
 				stmt->target = NULL;
 				stmt->need_to_push_result = false;
 				stmt->is_tsql_select_assign_stmt = false;
-				stmt->insert_exec = false;
 
 				attachPLtsql_fragment(ctx, (PLtsql_stmt *) stmt);
 				return (PLtsql_stmt *) stmt;


### PR DESCRIPTION
### Description

Currently, Babelfish carries two parallel implementations of INSERT ... EXECUTE, gated by the babelfishpg_tsql.enable_new_insert_exec GUC.
The original path goes via a tuple store based approach. The redesigned path introduced in PR0–PR4 (https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4780–https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4847) works on a temp table based approach.

The cleanup removes the enable_new_insert_exec GUC declaration, and the legacy insert-exec tuple store path.
Cherry-picked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4856
Related engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/776

### Issues Resolved

Final cleanup of the INSERT-EXEC redesign stack (PR0–PR4: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4780, https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4781, https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4782, https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4783, https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4847).

### Test Scenarios Covered ###

- Use case based — Existing INSERT-EXEC JDBC suites pass unchanged: stored-procedure INSERT EXEC, EXEC sp_executesql INSERT EXEC, dynamic-SQL INSERT EXEC, cross-database INSERT EXEC, INSERT EXEC into table variables, INSERT EXEC inside TRY/CATCH, and INSERT EXEC with explicit column lists.
- Boundary conditions — Nested INSERT EXEC, column-count mismatches between procedure output and target, and INSERT EXEC where the target relation is concurrently dropped/modified all behave as before the cleanup.
- Negative test cases — COMMIT and ROLLBACK inside an INSERT EXEC statement still raise the expected errors . INSERT EXEC inside a user-defined function still fails parser validation.
- Minor / Major version upgrade tests — No catalog or extension SQL changes; upgrades are unaffected.
- Performance tests — No performance-sensitive code path changed; only the dead branch of pre-existing runtime checks is removed.
- Tooling impact — babelfishpg_tsql.enable_new_insert_exec is removed from pg_settings. Any tooling or test harness that explicitly sets this GUC will receive an "unrecognized configuration parameter" error and must drop the setting.
- Client tests — Full JDBC test suite passes locally on the cleanup branch.


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).