### PR TITLE
Support RTE_NAMEDTUPLESTORE in FOR XML/JSON AUTO for trigger transition tables

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -1728,7 +1728,7 @@ isForAuto(List *target, ForAutoMode mode)
  * the target columns for nesting. Follows T-SQL behavior by reporting
  * "at least one table" error when no valid sources are found.
  *
- * Valid source types: RTE_RELATION, RTE_SUBQUERY, RTE_CTE, user-defined RTE_FUNCTION
+ * Valid source types: RTE_RELATION, RTE_SUBQUERY, RTE_CTE, RTE_NAMEDTUPLESTORE, user-defined RTE_FUNCTION
  */
 static bool
 handleForAuto(Query *wrapperQuery, ForAutoContext *ctx)
@@ -1778,7 +1778,8 @@ handleForAuto(Query *wrapperQuery, ForAutoContext *ctx)
 		foreach(lc, origqRtable)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_SUBQUERY || rte->rtekind == RTE_CTE)
+			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_SUBQUERY || rte->rtekind == RTE_CTE ||
+				rte->rtekind == RTE_NAMEDTUPLESTORE)
 			{
 				hasValidSrc = true;
 				break;
@@ -2041,8 +2042,9 @@ processAutoColumns(Query *wrapperQuery, Query *origQuery, Alias *wrapperRteAlias
 								   HASH_ELEM | HASH_STRINGS);
 
 	/*
-	 * XML AUTO: Pre-scan for first base table alias as fallback for
-	 * recursive CTE columns joined with base tables.
+	 * XML AUTO: Pre-scan for first base table or named tuplestore alias
+	 * as fallback for recursive CTE columns joined with base tables or
+	 * trigger transition tables.
 	 */
 	if (mode == FOR_AUTO_XML)
 	{
@@ -2050,7 +2052,7 @@ processAutoColumns(Query *wrapperQuery, Query *origQuery, Alias *wrapperRteAlias
 		foreach(preLc, origQuery->rtable)
 		{
 			RangeTblEntry *rte = (RangeTblEntry *) lfirst(preLc);
-			if (rte->rtekind == RTE_RELATION)
+			if (rte->rtekind == RTE_RELATION || rte->rtekind == RTE_NAMEDTUPLESTORE)
 			{
 				recursiveCTEFallbackAlias = rte->eref->aliasname;
 				break;
@@ -2141,14 +2143,14 @@ processAutoColumns(Query *wrapperQuery, Query *origQuery, Alias *wrapperRteAlias
 				{
 					matchedSrcCTEIsRecursive = true;
 
-					/* XML AUTO: look for base table sibling as fallback alias */
+					/* XML AUTO: look for base table or named tuplestore sibling as fallback alias */
 					if (mode == FOR_AUTO_XML)
 					{
 						ListCell *sibLc;
 						foreach(sibLc, curQuery->rtable)
 						{
 							RangeTblEntry *sibRte = (RangeTblEntry *) lfirst(sibLc);
-							if (sibRte->rtekind == RTE_RELATION)
+							if (sibRte->rtekind == RTE_RELATION || sibRte->rtekind == RTE_NAMEDTUPLESTORE)
 							{
 								recursiveCTEFallbackAlias = sibRte->eref->aliasname;
 								break;

--- a/test/JDBC/expected/forjsonauto-vu-cleanup.out
+++ b/test/JDBC/expected/forjsonauto-vu-cleanup.out
@@ -1,3 +1,24 @@
+
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_delete;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert_subset;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert_join;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_update_both;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_update_join;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert_null;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_delete_join;
+GO
+DROP TABLE IF EXISTS forjsonauto_t_trigger_json_result;
+GO
+DROP TABLE IF EXISTS forjsonauto_t_trigger_test;
+GO
 DROP VIEW forjson_vu_v_1
 GO
 

--- a/test/JDBC/expected/forjsonauto-vu-prepare.out
+++ b/test/JDBC/expected/forjsonauto-vu-prepare.out
@@ -438,3 +438,97 @@ VALUES
 GO
 ~~ROW COUNT: 1~~
 
+
+-- Trigger test tables (RTE_NAMEDTUPLESTORE)
+CREATE TABLE forjsonauto_t_trigger_test (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT
+);
+GO
+
+CREATE TABLE forjsonauto_t_trigger_json_result (
+    ResultJson NVARCHAR(MAX)
+);
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM inserted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_delete ON forjsonauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM deleted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT Name, Value FROM inserted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT i.ID, i.Name, t.Value
+            FROM inserted i
+            JOIN forjsonauto_t_trigger_test t ON i.ID = t.ID
+            FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM inserted FOR JSON AUTO)
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM deleted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT i.ID, i.Name AS NewName, i.Value AS NewValue, d.Value AS OldValue
+            FROM inserted i
+            JOIN deleted d ON i.ID = d.ID
+            FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM inserted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_delete_join ON forjsonauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT d.ID, d.Name, t.Value AS RemainingValue
+            FROM deleted d
+            JOIN forjsonauto_t_trigger_test t ON t.ID = 5
+            FOR JSON AUTO)
+END;
+GO
+
+-- Disable triggers not needed initially
+DISABLE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_delete_join ON forjsonauto_t_trigger_test;
+GO

--- a/test/JDBC/expected/forjsonauto-vu-verify.out
+++ b/test/JDBC/expected/forjsonauto-vu-verify.out
@@ -1796,3 +1796,248 @@ int#!#nvarchar
 1#!#[{"CustomerID": "ALFKI", "CompanyName": "Alfreds Inc", "ContactName": "Maria Anders", "Country": "USA", "Phone": "030-0074321"}]
 ~~END~~
 
+
+-- FOR JSON AUTO with INSERTED in AFTER INSERT trigger — single row
+INSERT INTO forjsonauto_t_trigger_test VALUES (1, 'Alice', 100);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"id": 1, "name": "Alice", "value": 100}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with INSERTED — multiple rows
+INSERT INTO forjsonauto_t_trigger_test VALUES (2, 'Bob', 200), (3, 'Charlie', 300);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"id": 2, "name": "Bob", "value": 200}, {"id": 3, "name": "Charlie", "value": 300}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with DELETED in AFTER DELETE trigger — single row
+DELETE FROM forjsonauto_t_trigger_test WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"id": 1, "name": "Alice", "value": 100}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with DELETED — multiple rows
+DELETE FROM forjsonauto_t_trigger_test WHERE ID IN (2, 3);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"id": 2, "name": "Bob", "value": 200}, {"id": 3, "name": "Charlie", "value": 300}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with INSERTED and column subset
+DISABLE TRIGGER forjsonauto_trg_insert ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test;
+GO
+
+INSERT INTO forjsonauto_t_trigger_test VALUES (4, 'Diana', 400);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"Name": "Diana", "Value": 400}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with INSERTED joined with base table
+DISABLE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test;
+GO
+
+INSERT INTO forjsonauto_t_trigger_test VALUES (5, 'Eve', 500);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"ID": 5, "Name": "Eve", "t": [{"Value": 500}]}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with UPDATE trigger (both inserted and deleted)
+DISABLE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_delete ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test;
+GO
+
+UPDATE forjsonauto_t_trigger_test SET Value = 999 WHERE ID = 4;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"id": 4, "name": "Diana", "value": 999}]
+[{"id": 4, "name": "Diana", "value": 400}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 2~~
+
+
+-- FOR JSON AUTO with inserted JOIN deleted in UPDATE trigger (nesting behavior)
+DISABLE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test;
+GO
+
+UPDATE forjsonauto_t_trigger_test SET Value = 888, Name = 'Updated' WHERE ID = 5;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"ID": 5, "NewName": "Updated", "NewValue": 888, "d": [{"OldValue": 500}]}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with NULL values in transition table columns
+DISABLE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test;
+GO
+
+INSERT INTO forjsonauto_t_trigger_test VALUES (6, NULL, NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"id": 6}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- FOR JSON AUTO with DELETED joined with base table
+DISABLE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_delete_join ON forjsonauto_t_trigger_test;
+GO
+
+DELETE FROM forjsonauto_t_trigger_test WHERE ID = 6;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+~~START~~
+nvarchar
+[{"ID": 6, "t": [{"RemainingValue": 888}]}]
+~~END~~
+
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+~~ROW COUNT: 1~~
+

--- a/test/JDBC/expected/forxml-auto-vu-cleanup.out
+++ b/test/JDBC/expected/forxml-auto-vu-cleanup.out
@@ -1,3 +1,41 @@
+-- Drop recursive CTE + trigger test objects
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_base_only;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_ins_only;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_base_first;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_ins_first;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_rcte_result;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_rcte_base;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_rcte;
+GO
+
+-- Drop triggers and trigger test tables
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_delete;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert_subset;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert_join;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_update_both;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_update_join;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert_null;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_delete_join;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_trigger_xml_result;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_trigger_test;
+GO
+
 -- Drop functions
 DROP FUNCTION IF EXISTS dbo.GetXmlCustomerOrders;
 GO

--- a/test/JDBC/expected/forxml-auto-vu-prepare.out
+++ b/test/JDBC/expected/forxml-auto-vu-prepare.out
@@ -387,3 +387,200 @@ INSERT INTO forxmlauto_t_ci_child VALUES (10, 1), (20, 2);
 GO
 ~~ROW COUNT: 2~~
 
+
+
+-- ============================================
+-- SECTION: Triggers (RTE_NAMEDTUPLESTORE)
+-- ============================================
+CREATE TABLE forxmlauto_t_trigger_test (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT
+);
+GO
+
+CREATE TABLE forxmlauto_t_trigger_xml_result (
+    ResultXml NVARCHAR(MAX)
+);
+GO
+
+-- Used by tests 21.1, 21.2
+CREATE TRIGGER forxmlauto_trg_insert ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM inserted FOR XML AUTO)
+END;
+GO
+
+-- Used by tests 21.3, 21.4
+CREATE TRIGGER forxmlauto_trg_delete ON forxmlauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM deleted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.5 (column subset)
+CREATE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT Name, Value FROM inserted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.6 (inserted joined with base table)
+CREATE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT i.ID, i.Name, t.Value
+            FROM inserted i
+            JOIN forxmlauto_t_trigger_test t ON i.ID = t.ID
+            FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.7 (update trigger - both inserted and deleted)
+CREATE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM inserted FOR XML AUTO)
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM deleted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.8 (inserted JOIN deleted in update trigger)
+CREATE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT i.ID, i.Name AS NewName, i.Value AS NewValue, d.Value AS OldValue
+            FROM inserted i
+            JOIN deleted d ON i.ID = d.ID
+            FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.9 (NULL values)
+CREATE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM inserted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.10 (deleted joined with base table)
+CREATE TRIGGER forxmlauto_trg_delete_join ON forxmlauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT d.ID, d.Name, t.Value AS RemainingValue
+            FROM deleted d
+            JOIN forxmlauto_t_trigger_test t ON t.ID = 5
+            FOR XML AUTO)
+END;
+GO
+
+-- Disable triggers that are not needed initially (will be enabled per-test in verify)
+DISABLE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_delete_join ON forxmlauto_t_trigger_test;
+GO
+
+
+
+-- ============================================
+-- SECTION: Recursive CTE + Trigger (fallback alias tests)
+-- ============================================
+CREATE TABLE forxmlauto_t_rcte (id int, parent_id int, val varchar(50));
+GO
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'Root'), (2, 1, 'Child');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE forxmlauto_t_rcte_base (id int, col varchar(50));
+GO
+INSERT INTO forxmlauto_t_rcte_base VALUES (1, 'X'), (2, 'Y');
+GO
+~~ROW COUNT: 2~~
+
+
+CREATE TABLE forxmlauto_t_rcte_result (result_xml nvarchar(max));
+GO
+
+-- Test: recursive CTE only with base table (no trigger)
+CREATE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT r.val, t.col FROM forxmlauto_t_rcte_base t JOIN rcte r ON t.id = r.id FOR XML AUTO)
+END;
+GO
+
+-- Test: recursive CTE with inserted only (RTE_NAMEDTUPLESTORE as fallback)
+CREATE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT r.val, i.val AS ins_val FROM inserted i JOIN rcte r ON i.id = r.id FOR XML AUTO)
+END;
+GO
+
+-- Test: recursive CTE with base table FIRST, then inserted
+CREATE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT b.col, i.val AS ins_val, r.val
+            FROM forxmlauto_t_rcte_base b
+            JOIN inserted i ON b.id = i.id
+            JOIN rcte r ON i.id = r.id
+            FOR XML AUTO)
+END;
+GO
+
+-- Test: recursive CTE with inserted FIRST, then base table
+CREATE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT i.val AS ins_val, b.col, r.val
+            FROM inserted i
+            JOIN forxmlauto_t_rcte_base b ON i.id = b.id
+            JOIN rcte r ON i.id = r.id
+            FOR XML AUTO)
+END;
+GO
+
+-- Disable all, will enable one at a time in verify
+DISABLE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte;
+GO
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte;
+GO
+DISABLE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte;
+GO
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte;
+GO

--- a/test/JDBC/expected/forxml-auto-vu-verify.out
+++ b/test/JDBC/expected/forxml-auto-vu-verify.out
@@ -2237,3 +2237,376 @@ ntext
 ~~END~~
 
 
+
+
+-- ============================================
+-- SECTION 21: NAMEDTUPLESTORE (Triggers with INSERTED/DELETED)
+-- ============================================
+-- 21.1 FOR XML AUTO with INSERTED in AFTER INSERT trigger
+INSERT INTO forxmlauto_t_trigger_test VALUES (1, 'Alice', 100);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<inserted id="1" name="Alice" value="100"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.2 FOR XML AUTO with INSERTED — multiple rows
+INSERT INTO forxmlauto_t_trigger_test VALUES (2, 'Bob', 200), (3, 'Charlie', 300);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<inserted id="2" name="Bob" value="200"/><inserted id="3" name="Charlie" value="300"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.3 FOR XML AUTO with DELETED in AFTER DELETE trigger
+DELETE FROM forxmlauto_t_trigger_test WHERE ID = 1;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<deleted id="1" name="Alice" value="100"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.4 FOR XML AUTO with DELETED — multiple rows
+DELETE FROM forxmlauto_t_trigger_test WHERE ID IN (2, 3);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 2~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<deleted id="2" name="Bob" value="200"/><deleted id="3" name="Charlie" value="300"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.5 FOR XML AUTO with INSERTED and column subset
+DISABLE TRIGGER forxmlauto_trg_insert ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test;
+GO
+
+INSERT INTO forxmlauto_t_trigger_test VALUES (4, 'Diana', 400);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<inserted Name="Diana" Value="400"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.6 FOR XML AUTO with INSERTED joined with base table
+DISABLE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test;
+GO
+
+INSERT INTO forxmlauto_t_trigger_test VALUES (5, 'Eve', 500);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<i ID="5" Name="Eve"><t Value="500"/></i>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.7 FOR XML AUTO with UPDATE trigger (both inserted and deleted)
+DISABLE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_delete ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test;
+GO
+
+UPDATE forxmlauto_t_trigger_test SET Value = 999 WHERE ID = 4;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<inserted id="4" name="Diana" value="999"/>
+<deleted id="4" name="Diana" value="400"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 2~~
+
+
+-- 21.8 FOR XML AUTO with inserted JOIN deleted in UPDATE trigger (nesting behavior)
+DISABLE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test;
+GO
+
+UPDATE forxmlauto_t_trigger_test SET Value = 888, Name = 'Updated' WHERE ID = 5;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<i ID="5" NewName="Updated" NewValue="888"><d OldValue="500"/></i>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.9 FOR XML AUTO with NULL values in transition table columns
+DISABLE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test;
+GO
+
+INSERT INTO forxmlauto_t_trigger_test VALUES (6, NULL, NULL);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<inserted id="6"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+-- 21.10 FOR XML AUTO with DELETED joined with base table
+DISABLE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_delete_join ON forxmlauto_t_trigger_test;
+GO
+
+DELETE FROM forxmlauto_t_trigger_test WHERE ID = 6;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+~~START~~
+nvarchar
+<d ID="6"><t RemainingValue="888"/></d>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+~~ROW COUNT: 1~~
+
+
+
+-- ============================================
+-- SECTION 22: Recursive CTE fallback alias with trigger transition tables
+-- ============================================
+-- 22.1 Recursive CTE joined with base table (RTE_RELATION as fallback alias)
+ENABLE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+~~START~~
+nvarchar
+<t val="Root" col="X"/><t val="New" col="X"/><t val="Child" col="Y"/><t val="Child" col="Y"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+DISABLE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte;
+GO
+
+-- 22.2 Recursive CTE joined with inserted only (RTE_NAMEDTUPLESTORE as fallback alias)
+ENABLE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+~~START~~
+nvarchar
+<i val="Root" ins_val="New"/><i val="New" ins_val="New"/>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte;
+GO
+
+-- 22.3 Recursive CTE with base table FIRST, then inserted
+ENABLE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+~~START~~
+nvarchar
+<b col="X"><i ins_val="New" val="Root"/><i ins_val="New" val="New"/></b>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+DISABLE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte;
+GO
+
+-- 22.4 Recursive CTE with inserted FIRST, then base table
+ENABLE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+~~START~~
+nvarchar
+<i ins_val="New"><b col="X" val="Root"/><b col="X" val="New"/></i>
+~~END~~
+
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte;
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-cleanup.sql
@@ -1,3 +1,24 @@
+
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_delete;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert_subset;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert_join;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_update_both;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_update_join;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_insert_null;
+GO
+DROP TRIGGER IF EXISTS forjsonauto_trg_delete_join;
+GO
+DROP TABLE IF EXISTS forjsonauto_t_trigger_json_result;
+GO
+DROP TABLE IF EXISTS forjsonauto_t_trigger_test;
+GO
 DROP VIEW forjson_vu_v_1
 GO
 

--- a/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-prepare.sql
@@ -392,3 +392,97 @@ VALUES
       WHERE CustomerID = 'ALFKI' 
       FOR JSON AUTO));
 GO
+
+-- Trigger test tables (RTE_NAMEDTUPLESTORE)
+CREATE TABLE forjsonauto_t_trigger_test (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT
+);
+GO
+
+CREATE TABLE forjsonauto_t_trigger_json_result (
+    ResultJson NVARCHAR(MAX)
+);
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM inserted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_delete ON forjsonauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM deleted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT Name, Value FROM inserted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT i.ID, i.Name, t.Value
+            FROM inserted i
+            JOIN forjsonauto_t_trigger_test t ON i.ID = t.ID
+            FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM inserted FOR JSON AUTO)
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM deleted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT i.ID, i.Name AS NewName, i.Value AS NewValue, d.Value AS OldValue
+            FROM inserted i
+            JOIN deleted d ON i.ID = d.ID
+            FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT * FROM inserted FOR JSON AUTO)
+END;
+GO
+
+CREATE TRIGGER forjsonauto_trg_delete_join ON forjsonauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forjsonauto_t_trigger_json_result(ResultJson)
+    SELECT (SELECT d.ID, d.Name, t.Value AS RemainingValue
+            FROM deleted d
+            JOIN forjsonauto_t_trigger_test t ON t.ID = 5
+            FOR JSON AUTO)
+END;
+GO
+
+-- Disable triggers not needed initially
+DISABLE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_delete_join ON forjsonauto_t_trigger_test;
+GO

--- a/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
+++ b/test/JDBC/input/forjson/forjsonauto-vu-verify.sql
@@ -1270,3 +1270,135 @@ GO
 -- SELECT FROM a table which value is a result of FOR JSON AUTO
 SELECT * FROM JsonTable;
 GO
+
+-- FOR JSON AUTO with INSERTED in AFTER INSERT trigger — single row
+INSERT INTO forjsonauto_t_trigger_test VALUES (1, 'Alice', 100);
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with INSERTED — multiple rows
+INSERT INTO forjsonauto_t_trigger_test VALUES (2, 'Bob', 200), (3, 'Charlie', 300);
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with DELETED in AFTER DELETE trigger — single row
+DELETE FROM forjsonauto_t_trigger_test WHERE ID = 1;
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with DELETED — multiple rows
+DELETE FROM forjsonauto_t_trigger_test WHERE ID IN (2, 3);
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with INSERTED and column subset
+DISABLE TRIGGER forjsonauto_trg_insert ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test;
+GO
+
+INSERT INTO forjsonauto_t_trigger_test VALUES (4, 'Diana', 400);
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with INSERTED joined with base table
+DISABLE TRIGGER forjsonauto_trg_insert_subset ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test;
+GO
+
+INSERT INTO forjsonauto_t_trigger_test VALUES (5, 'Eve', 500);
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with UPDATE trigger (both inserted and deleted)
+DISABLE TRIGGER forjsonauto_trg_insert_join ON forjsonauto_t_trigger_test;
+GO
+DISABLE TRIGGER forjsonauto_trg_delete ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test;
+GO
+
+UPDATE forjsonauto_t_trigger_test SET Value = 999 WHERE ID = 4;
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with inserted JOIN deleted in UPDATE trigger (nesting behavior)
+DISABLE TRIGGER forjsonauto_trg_update_both ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test;
+GO
+
+UPDATE forjsonauto_t_trigger_test SET Value = 888, Name = 'Updated' WHERE ID = 5;
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with NULL values in transition table columns
+DISABLE TRIGGER forjsonauto_trg_update_join ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test;
+GO
+
+INSERT INTO forjsonauto_t_trigger_test VALUES (6, NULL, NULL);
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO
+
+-- FOR JSON AUTO with DELETED joined with base table
+DISABLE TRIGGER forjsonauto_trg_insert_null ON forjsonauto_t_trigger_test;
+GO
+ENABLE TRIGGER forjsonauto_trg_delete_join ON forjsonauto_t_trigger_test;
+GO
+
+DELETE FROM forjsonauto_t_trigger_test WHERE ID = 6;
+GO
+
+SELECT ResultJson FROM forjsonauto_t_trigger_json_result;
+GO
+
+DELETE FROM forjsonauto_t_trigger_json_result;
+GO

--- a/test/JDBC/input/forxml/forxml-auto-vu-cleanup.sql
+++ b/test/JDBC/input/forxml/forxml-auto-vu-cleanup.sql
@@ -1,3 +1,41 @@
+-- Drop recursive CTE + trigger test objects
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_base_only;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_ins_only;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_base_first;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_rcte_ins_first;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_rcte_result;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_rcte_base;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_rcte;
+GO
+
+-- Drop triggers and trigger test tables
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_delete;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert_subset;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert_join;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_update_both;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_update_join;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_insert_null;
+GO
+DROP TRIGGER IF EXISTS forxmlauto_trg_delete_join;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_trigger_xml_result;
+GO
+DROP TABLE IF EXISTS forxmlauto_t_trigger_test;
+GO
+
 -- Drop functions
 DROP FUNCTION IF EXISTS dbo.GetXmlCustomerOrders;
 GO

--- a/test/JDBC/input/forxml/forxml-auto-vu-prepare.sql
+++ b/test/JDBC/input/forxml/forxml-auto-vu-prepare.sql
@@ -339,3 +339,196 @@ GO
 
 INSERT INTO forxmlauto_t_ci_child VALUES (10, 1), (20, 2);
 GO
+
+-- ============================================
+-- SECTION: Triggers (RTE_NAMEDTUPLESTORE)
+-- ============================================
+
+CREATE TABLE forxmlauto_t_trigger_test (
+    ID INT PRIMARY KEY,
+    Name NVARCHAR(50),
+    Value INT
+);
+GO
+
+CREATE TABLE forxmlauto_t_trigger_xml_result (
+    ResultXml NVARCHAR(MAX)
+);
+GO
+
+-- Used by tests 21.1, 21.2
+CREATE TRIGGER forxmlauto_trg_insert ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM inserted FOR XML AUTO)
+END;
+GO
+
+-- Used by tests 21.3, 21.4
+CREATE TRIGGER forxmlauto_trg_delete ON forxmlauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM deleted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.5 (column subset)
+CREATE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT Name, Value FROM inserted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.6 (inserted joined with base table)
+CREATE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT i.ID, i.Name, t.Value
+            FROM inserted i
+            JOIN forxmlauto_t_trigger_test t ON i.ID = t.ID
+            FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.7 (update trigger - both inserted and deleted)
+CREATE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM inserted FOR XML AUTO)
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM deleted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.8 (inserted JOIN deleted in update trigger)
+CREATE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test AFTER UPDATE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT i.ID, i.Name AS NewName, i.Value AS NewValue, d.Value AS OldValue
+            FROM inserted i
+            JOIN deleted d ON i.ID = d.ID
+            FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.9 (NULL values)
+CREATE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test AFTER INSERT AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT * FROM inserted FOR XML AUTO)
+END;
+GO
+
+-- Used by test 21.10 (deleted joined with base table)
+CREATE TRIGGER forxmlauto_trg_delete_join ON forxmlauto_t_trigger_test AFTER DELETE AS
+BEGIN
+    INSERT INTO forxmlauto_t_trigger_xml_result(ResultXml)
+    SELECT (SELECT d.ID, d.Name, t.Value AS RemainingValue
+            FROM deleted d
+            JOIN forxmlauto_t_trigger_test t ON t.ID = 5
+            FOR XML AUTO)
+END;
+GO
+
+-- Disable triggers that are not needed initially (will be enabled per-test in verify)
+DISABLE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_delete_join ON forxmlauto_t_trigger_test;
+GO
+
+
+-- ============================================
+-- SECTION: Recursive CTE + Trigger (fallback alias tests)
+-- ============================================
+
+CREATE TABLE forxmlauto_t_rcte (id int, parent_id int, val varchar(50));
+GO
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'Root'), (2, 1, 'Child');
+GO
+
+CREATE TABLE forxmlauto_t_rcte_base (id int, col varchar(50));
+GO
+INSERT INTO forxmlauto_t_rcte_base VALUES (1, 'X'), (2, 'Y');
+GO
+
+CREATE TABLE forxmlauto_t_rcte_result (result_xml nvarchar(max));
+GO
+
+-- Test: recursive CTE only with base table (no trigger)
+CREATE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT r.val, t.col FROM forxmlauto_t_rcte_base t JOIN rcte r ON t.id = r.id FOR XML AUTO)
+END;
+GO
+
+-- Test: recursive CTE with inserted only (RTE_NAMEDTUPLESTORE as fallback)
+CREATE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT r.val, i.val AS ins_val FROM inserted i JOIN rcte r ON i.id = r.id FOR XML AUTO)
+END;
+GO
+
+-- Test: recursive CTE with base table FIRST, then inserted
+CREATE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT b.col, i.val AS ins_val, r.val
+            FROM forxmlauto_t_rcte_base b
+            JOIN inserted i ON b.id = i.id
+            JOIN rcte r ON i.id = r.id
+            FOR XML AUTO)
+END;
+GO
+
+-- Test: recursive CTE with inserted FIRST, then base table
+CREATE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte AFTER INSERT AS
+BEGIN
+    ;WITH rcte AS (
+        SELECT id, val FROM forxmlauto_t_rcte WHERE parent_id IS NULL
+        UNION ALL
+        SELECT t.id, t.val FROM forxmlauto_t_rcte t JOIN rcte r ON t.parent_id = r.id
+    )
+    INSERT INTO forxmlauto_t_rcte_result(result_xml)
+    SELECT (SELECT i.val AS ins_val, b.col, r.val
+            FROM inserted i
+            JOIN forxmlauto_t_rcte_base b ON i.id = b.id
+            JOIN rcte r ON i.id = r.id
+            FOR XML AUTO)
+END;
+GO
+
+-- Disable all, will enable one at a time in verify
+DISABLE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte;
+GO
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte;
+GO
+DISABLE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte;
+GO
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte;
+GO

--- a/test/JDBC/input/forxml/forxml-auto-vu-verify.sql
+++ b/test/JDBC/input/forxml/forxml-auto-vu-verify.sql
@@ -1477,3 +1477,211 @@ FOR XML AUTO;
 COMMIT;
 GO
 
+
+
+-- ============================================
+-- SECTION 21: NAMEDTUPLESTORE (Triggers with INSERTED/DELETED)
+-- ============================================
+-- 21.1 FOR XML AUTO with INSERTED in AFTER INSERT trigger
+INSERT INTO forxmlauto_t_trigger_test VALUES (1, 'Alice', 100);
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.2 FOR XML AUTO with INSERTED — multiple rows
+INSERT INTO forxmlauto_t_trigger_test VALUES (2, 'Bob', 200), (3, 'Charlie', 300);
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.3 FOR XML AUTO with DELETED in AFTER DELETE trigger
+DELETE FROM forxmlauto_t_trigger_test WHERE ID = 1;
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.4 FOR XML AUTO with DELETED — multiple rows
+DELETE FROM forxmlauto_t_trigger_test WHERE ID IN (2, 3);
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.5 FOR XML AUTO with INSERTED and column subset
+DISABLE TRIGGER forxmlauto_trg_insert ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test;
+GO
+
+INSERT INTO forxmlauto_t_trigger_test VALUES (4, 'Diana', 400);
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.6 FOR XML AUTO with INSERTED joined with base table
+DISABLE TRIGGER forxmlauto_trg_insert_subset ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test;
+GO
+
+INSERT INTO forxmlauto_t_trigger_test VALUES (5, 'Eve', 500);
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.7 FOR XML AUTO with UPDATE trigger (both inserted and deleted)
+DISABLE TRIGGER forxmlauto_trg_insert_join ON forxmlauto_t_trigger_test;
+GO
+DISABLE TRIGGER forxmlauto_trg_delete ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test;
+GO
+
+UPDATE forxmlauto_t_trigger_test SET Value = 999 WHERE ID = 4;
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.8 FOR XML AUTO with inserted JOIN deleted in UPDATE trigger (nesting behavior)
+DISABLE TRIGGER forxmlauto_trg_update_both ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test;
+GO
+
+UPDATE forxmlauto_t_trigger_test SET Value = 888, Name = 'Updated' WHERE ID = 5;
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.9 FOR XML AUTO with NULL values in transition table columns
+DISABLE TRIGGER forxmlauto_trg_update_join ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test;
+GO
+
+INSERT INTO forxmlauto_t_trigger_test VALUES (6, NULL, NULL);
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+-- 21.10 FOR XML AUTO with DELETED joined with base table
+DISABLE TRIGGER forxmlauto_trg_insert_null ON forxmlauto_t_trigger_test;
+GO
+ENABLE TRIGGER forxmlauto_trg_delete_join ON forxmlauto_t_trigger_test;
+GO
+
+DELETE FROM forxmlauto_t_trigger_test WHERE ID = 6;
+GO
+
+SELECT ResultXml FROM forxmlauto_t_trigger_xml_result;
+GO
+
+DELETE FROM forxmlauto_t_trigger_xml_result;
+GO
+
+
+-- ============================================
+-- SECTION 22: Recursive CTE fallback alias with trigger transition tables
+-- ============================================
+-- 22.1 Recursive CTE joined with base table (RTE_RELATION as fallback alias)
+ENABLE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+
+DISABLE TRIGGER forxmlauto_trg_rcte_base_only ON forxmlauto_t_rcte;
+GO
+
+-- 22.2 Recursive CTE joined with inserted only (RTE_NAMEDTUPLESTORE as fallback alias)
+ENABLE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_only ON forxmlauto_t_rcte;
+GO
+
+-- 22.3 Recursive CTE with base table FIRST, then inserted
+ENABLE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+
+DISABLE TRIGGER forxmlauto_trg_rcte_base_first ON forxmlauto_t_rcte;
+GO
+
+-- 22.4 Recursive CTE with inserted FIRST, then base table
+ENABLE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte;
+GO
+
+INSERT INTO forxmlauto_t_rcte VALUES (1, NULL, 'New');
+GO
+
+SELECT result_xml FROM forxmlauto_t_rcte_result;
+GO
+
+DELETE FROM forxmlauto_t_rcte_result;
+DELETE FROM forxmlauto_t_rcte WHERE val = 'New';
+GO
+
+DISABLE TRIGGER forxmlauto_trg_rcte_ins_first ON forxmlauto_t_rcte;
+GO


### PR DESCRIPTION
### Description

Currently, Babelfish's FOR XML AUTO and FOR JSON AUTO fail with "requires at least one table" when the query source is a named tuplestore specifically the INSERTED and DELETED transition tables inside AFTER triggers. With this change, these transition tables are now recognized as valid sources, and the query produces correct hierarchical XML/JSON output using the tuplestore name (e.g., "inserted", "deleted") as the element/object key name.

The fix was needed because PostgreSQL represents trigger transition tables as RTE_NAMEDTUPLESTORE range table entries, but the FOR AUTO valid-source check only accepted RTE_RELATION, RTE_SUBQUERY, RTE_CTE, RTE_GROUP, and user-defined RTE_FUNCTION.

Cherrypicked from: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4909

Authored-by: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

### Issues Resolved

BABEL-6878

### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -** Yes


* **Arbitrary inputs -**  Yes


* **Negative test cases -** Yes


* **Minor version upgrade tests -** N/A


* **Major version upgrade tests -** N/A


* **Performance tests -** N/A


* **Tooling impact -** None


* **Client tests -** Yes



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).