### PR TITLE
Return SQL Server canonical casing for collation name in SERVERPROPERTY

### DIFF
--- a/contrib/babelfishpg_tsql/src/collation.c
+++ b/contrib/babelfishpg_tsql/src/collation.c
@@ -1900,6 +1900,55 @@ pltsql_replace_non_determinstic(text *src_text, text *from_text, text *to_text, 
 	return false;
 }
 
+char *
+get_display_collation_name(const char *collname)
+{
+	char	   *result;
+	char	   *token;
+
+	if (collname == NULL)
+		return NULL;
+
+	result = pstrdup(collname);
+
+	if (strncmp(result, "bbf_", 4) == 0)
+		return result;
+
+	token = result;
+	while (token != NULL && *token != '\0')
+	{
+		char	   *next = strchr(token, '_');
+		size_t		len = next ? (size_t) (next - token) : strlen(token);
+		bool		upper_all;
+		size_t		i;
+
+		upper_all = (len == 2 && (strncmp(token, "ci", len) == 0 ||
+								  strncmp(token, "cs", len) == 0 ||
+								  strncmp(token, "ai", len) == 0 ||
+								  strncmp(token, "as", len) == 0 ||
+								  strncmp(token, "ks", len) == 0 ||
+								  strncmp(token, "ws", len) == 0)) ||
+			(len == 3 && (strncmp(token, "sql", len) == 0 ||
+						  strncmp(token, "prc", len) == 0 ||
+						  strncmp(token, "bin", len) == 0)) ||
+			(len == 4 && strncmp(token, "bin2", len) == 0) ||
+			(len > 2 && strncmp(token, "cp", 2) == 0 &&
+			 isdigit((unsigned char) token[2]));
+
+		if (upper_all)
+		{
+			for (i = 0; i < len; i++)
+				token[i] = pg_toupper((unsigned char) token[i]);
+		}
+		else
+			token[0] = pg_toupper((unsigned char) token[0]);
+
+		token = next ? next + 1 : NULL;
+	}
+
+	return result;
+}
+
 /* Find the collation corresponding to a specific database */
 char*
 get_collation_name_for_db(const char* dbname)

--- a/contrib/babelfishpg_tsql/src/collation.h
+++ b/contrib/babelfishpg_tsql/src/collation.h
@@ -127,6 +127,7 @@ extern Node *pltsql_predicate_transformer(Node *expr, bool is_constraint);
 void set_db_collation_internal(const char *db_name);
 bool supported_collation_for_db_and_like(int32_t code_page);
 char* get_collation_name_for_db(const char* dbname);
+char* get_display_collation_name(const char *collname);
 
 /* Expression kind codes for preprocess_expression */
 #define EXPRKIND_QUAL				0

--- a/contrib/babelfishpg_tsql/src/properties.c
+++ b/contrib/babelfishpg_tsql/src/properties.c
@@ -263,7 +263,12 @@ serverproperty(PG_FUNCTION_ARGS)
 		const char *server_collation_name = GetConfigOption("babelfishpg_tsql.server_collation_name", false, false);
 
 		if (server_collation_name)
-			vch = (*common_utility_plugin_ptr->tsql_varchar_input) (server_collation_name, strlen(server_collation_name), -1);
+		{
+			char	   *display_name = get_display_collation_name(server_collation_name);
+
+			vch = (*common_utility_plugin_ptr->tsql_varchar_input) (display_name, strlen(display_name), -1);
+			pfree(display_name);
+		}
 	}
 	else if (strcasecmp(property, "CollationID") == 0)
 	{

--- a/test/JDBC/expected/BABEL-SERVERPROPERTY.out
+++ b/test/JDBC/expected/BABEL-SERVERPROPERTY.out
@@ -12,7 +12,7 @@ select serverproperty('collation');
 go
 ~~START~~
 sql_variant
-sql_latin1_general_cp1_ci_as
+SQL_Latin1_General_CP1_CI_AS
 ~~END~~
 
 select 'true' where serverproperty('collationId') >= 0;

--- a/test/JDBC/expected/babel_function.out
+++ b/test/JDBC/expected/babel_function.out
@@ -413,7 +413,7 @@ select serverproperty(N'collation');
 GO
 ~~START~~
 sql_variant
-sql_latin1_general_cp1_ci_as
+SQL_Latin1_General_CP1_CI_AS
 ~~END~~
 
 select serverproperty(N'IsSingleUser');

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-SERVERPROPERTY.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/BABEL-SERVERPROPERTY.out
@@ -12,7 +12,7 @@ select serverproperty('collation');
 go
 ~~START~~
 sql_variant
-chinese_prc_ci_as
+Chinese_PRC_CI_AS
 ~~END~~
 
 select 'true' where serverproperty('collationId') >= 0;

--- a/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_function.out
+++ b/test/JDBC/expected/non_default_server_collation/chinese_prc_ci_as/babel_function.out
@@ -413,7 +413,7 @@ select serverproperty(N'collation');
 GO
 ~~START~~
 sql_variant
-chinese_prc_ci_as
+Chinese_PRC_CI_AS
 ~~END~~
 
 select serverproperty(N'IsSingleUser');


### PR DESCRIPTION
### Description

Babelfish stores T-SQL collation names in lowercase internally (pg_collation lowercases identifiers), and SERVERPROPERTY('Collation') returned that internal lowercase form, e.g. sql_latin1_general_cp1_ci_as. SQL Server returns the canonical casing SQL_Latin1_General_CP1_CI_AS, and applications that check the collation name case-sensitively (e.g. testing for '_CI_') break against Babelfish.

Fix this at the output boundary: a new helper get_display_collation_name() translates an internal lowercase collation name into the casing SQL Server uses for display. Sort flags (CI/CS/AI/AS/KS/WS/BIN/BIN2), code pages (CP1250, ...) and the abbreviations SQL/PRC are fully uppercased, all other words are capitalized. Babelfish-specific bbf_* collations have no SQL Server counterpart and are returned unchanged. SERVERPROPERTY('Collation') now routes its result through this helper; the internally stored names are not changed.

DATABASEPROPERTYEX(<db>, 'Collation'), fn_helpcollations() and sys.databases.collation_name intentionally keep exposing the internal lowercase names: they are all backed by catalogs that store lowercase names, and since sql_variant comparisons are case-sensitive, canonicalizing DATABASEPROPERTYEX alone would break existing joins such as `fn_helpcollations() [Name] = DATABASEPROPERTYEX(DB_NAME(), 'Collation')` (this showed up as BABEL-3299/babel_collation failures in the non-default server collation CI suite in an earlier revision of this PR). Making those consistent requires catalog changes with extension upgrade scripts and is left for a follow-up.

Task: BABEL-4884

### Issues Resolved

Fixes #4884

### Test Scenarios Covered ###
* **Use case based -** Updated JDBC expected outputs for SERVERPROPERTY('Collation') (BABEL-SERVERPROPERTY, babel_function) in the default and non_default_server_collation (chinese_prc_ci_as) suites; verified the mapping against every collation in coll_infos/coll_translations.


* **Boundary conditions -** bbf_* collations are returned unchanged; NULL input returns NULL.


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
