### PR TITLE
[OSS-ONLY] Reset pg_strtok state after PLtsql node deserialization and test fixes

### DIFF
--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.0.0--6.1.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.0.0--6.1.0.sql
@@ -238,31 +238,6 @@ $$
     end;
 $$;
 
--- BABELFISH_FUNCTION_EXT (antlr_parse_cache)
-SET allow_system_table_mods = on;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_tree TEXT DEFAULT NULL;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_datums TEXT DEFAULT NULL;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_bbf_version TEXT DEFAULT NULL;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_enabled BOOL DEFAULT NULL;
-RESET allow_system_table_mods;
-
-CREATE OR REPLACE FUNCTION sys.enable_antlr_parse_cache(
-    IN routine_id OID,
-    IN use_antlr_parse_cache BOOLEAN
-) RETURNS BOOLEAN
-AS 'babelfishpg_tsql', 'enable_antlr_parse_cache'
-LANGUAGE C VOLATILE PARALLEL UNSAFE;
-
-CREATE OR REPLACE FUNCTION sys.antlr_parse_cache_stats(
-    OUT cache_hits INT,
-    OUT cache_misses INT,
-    OUT cache_writes INT,
-    OUT cache_evictions INT,
-    OUT cache_errors INT
-) RETURNS RECORD
-AS 'babelfishpg_tsql', 'antlr_parse_cache_stats'
-LANGUAGE C VOLATILE PARALLEL RESTRICTED;
-
 -- Please add your SQLs here
 
 -- Deprecate and drop old aggregates first (they depend on the function)

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.2.0--6.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.2.0--6.3.0.sql
@@ -36,6 +36,31 @@ end
 $$
 LANGUAGE plpgsql;
 
+-- BABELFISH_FUNCTION_EXT (antlr_parse_cache)
+SET allow_system_table_mods = on;
+ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_tree TEXT DEFAULT NULL;
+ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_datums TEXT DEFAULT NULL;
+ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_bbf_version TEXT DEFAULT NULL;
+ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_enabled BOOL DEFAULT NULL;
+RESET allow_system_table_mods;
+
+CREATE OR REPLACE FUNCTION sys.enable_antlr_parse_cache(
+    IN routine_id OID,
+    IN use_antlr_parse_cache BOOLEAN
+) RETURNS BOOLEAN
+AS 'babelfishpg_tsql', 'enable_antlr_parse_cache'
+LANGUAGE C VOLATILE PARALLEL UNSAFE;
+
+CREATE OR REPLACE FUNCTION sys.antlr_parse_cache_stats(
+    OUT cache_hits INT,
+    OUT cache_misses INT,
+    OUT cache_writes INT,
+    OUT cache_evictions INT,
+    OUT cache_errors INT
+) RETURNS RECORD
+AS 'babelfishpg_tsql', 'antlr_parse_cache_stats'
+LANGUAGE C VOLATILE PARALLEL RESTRICTED;
+
 -- please add your SQL here
 /*
  * Note: These SQL statements may get executed multiple times specially when some features get backpatched.

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.2.0--6.3.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--6.2.0--6.3.0.sql
@@ -36,31 +36,6 @@ end
 $$
 LANGUAGE plpgsql;
 
--- BABELFISH_FUNCTION_EXT (antlr_parse_cache)
-SET allow_system_table_mods = on;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_tree TEXT DEFAULT NULL;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_datums TEXT DEFAULT NULL;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_bbf_version TEXT DEFAULT NULL;
-ALTER TABLE sys.babelfish_function_ext ADD COLUMN IF NOT EXISTS antlr_parse_cache_enabled BOOL DEFAULT NULL;
-RESET allow_system_table_mods;
-
-CREATE OR REPLACE FUNCTION sys.enable_antlr_parse_cache(
-    IN routine_id OID,
-    IN use_antlr_parse_cache BOOLEAN
-) RETURNS BOOLEAN
-AS 'babelfishpg_tsql', 'enable_antlr_parse_cache'
-LANGUAGE C VOLATILE PARALLEL UNSAFE;
-
-CREATE OR REPLACE FUNCTION sys.antlr_parse_cache_stats(
-    OUT cache_hits INT,
-    OUT cache_misses INT,
-    OUT cache_writes INT,
-    OUT cache_evictions INT,
-    OUT cache_errors INT
-) RETURNS RECORD
-AS 'babelfishpg_tsql', 'antlr_parse_cache_stats'
-LANGUAGE C VOLATILE PARALLEL RESTRICTED;
-
 -- please add your SQL here
 /*
  * Note: These SQL statements may get executed multiple times specially when some features get backpatched.

--- a/contrib/babelfishpg_tsql/src/pltsql_node/pltsql_nodeio.c
+++ b/contrib/babelfishpg_tsql/src/pltsql_node/pltsql_nodeio.c
@@ -441,5 +441,7 @@ pltsql_stringToNode(const char *str)
 
 	retval = pltsql_nodeRead(NULL, 0);
 
+	pg_strtok_init(NULL);
+
 	return retval;
 }

--- a/test/JDBC/expected/BABEL-6037-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-6037-vu-cleanup.out
@@ -85,8 +85,7 @@ DROP PROCEDURE IF EXISTS dbo.perfunc_default_test;
 GO
 DROP PROCEDURE IF EXISTS test_cache_schema.perfunc_custom_schema;
 GO
-DROP PROCEDURE IF EXISTS dbo.validate_cache_proc;
-GO
+-- validate_cache_proc dropped in antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP PROCEDURE IF EXISTS dbo.nocache_create_proc;
 GO
 DROP PROCEDURE IF EXISTS dbo.overload_cache_proc;
@@ -105,10 +104,8 @@ DROP TABLE IF EXISTS dbo.dep_rename_table;
 GO
 DROP TABLE IF EXISTS dbo.dep_renamed_table;
 GO
-DROP FUNCTION IF EXISTS dbo.corrupt_cache_test_func;
-GO
-DROP PROCEDURE IF EXISTS dbo.version_mismatch;
-GO
+-- corrupt_cache_test_func and version_mismatch dropped in
+-- antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP USER IF EXISTS babel_6037_nonowner;
 GO
 DROP LOGIN babel_6037_nonowner;

--- a/test/JDBC/expected/BABEL-6037-vu-cleanup.out
+++ b/test/JDBC/expected/BABEL-6037-vu-cleanup.out
@@ -85,7 +85,6 @@ DROP PROCEDURE IF EXISTS dbo.perfunc_default_test;
 GO
 DROP PROCEDURE IF EXISTS test_cache_schema.perfunc_custom_schema;
 GO
--- validate_cache_proc dropped in antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP PROCEDURE IF EXISTS dbo.nocache_create_proc;
 GO
 DROP PROCEDURE IF EXISTS dbo.overload_cache_proc;
@@ -104,8 +103,6 @@ DROP TABLE IF EXISTS dbo.dep_rename_table;
 GO
 DROP TABLE IF EXISTS dbo.dep_renamed_table;
 GO
--- corrupt_cache_test_func and version_mismatch dropped in
--- antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP USER IF EXISTS babel_6037_nonowner;
 GO
 DROP LOGIN babel_6037_nonowner;

--- a/test/JDBC/expected/BABEL-6037-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-6037-vu-prepare.out
@@ -341,10 +341,6 @@ END;
 GO
 
 
--- Test 22 (validate_cache_proc), Test 27 (corrupt_cache_test_func), and Test 28
--- (version_mismatch) moved to antlr_parse_cache_local_regression_only-vu-prepare.mix
--- since they require true Postgres superuser privileges (PGC_SUSET GUC and
--- allow_system_table_mods). See BABEL-6879.
 -- Test 23: Procedure created with cache OFF, executed with cache ON in verify
 -- Tests that pltsql_update_func_cache_entry populates cache at EXEC time
 SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);

--- a/test/JDBC/expected/BABEL-6037-vu-prepare.out
+++ b/test/JDBC/expected/BABEL-6037-vu-prepare.out
@@ -340,65 +340,11 @@ BEGIN
 END;
 GO
 
--- psql
--- Test 22: Validation procedure with complex statement types
--- Used with pltsql_validate_antlr_parse_cache GUC to compare cached vs ANTLR trees
--- Note: validation GUC is SUSET (superuser only), so we set it at database level
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = on;
-GO
 
--- tsql
-
-
-
-
-
-
-
-CREATE PROCEDURE dbo.validate_cache_proc
-    @input INT,
-    @name VARCHAR(50)
-AS
-BEGIN
-    DECLARE @counter INT;
-    DECLARE @result VARCHAR(100);
-    DECLARE @flag BIT;
-    SET @counter = 0;
-    SET @flag = 1;
-    -- IF/ELSE
-    IF @input > 10
-        SET @result = 'large';
-    ELSE
-        SET @result = 'small';
-    -- WHILE loop
-    WHILE @counter < @input
-    BEGIN
-        SET @counter = @counter + 1;
-        IF @counter = 5
-            BREAK;
-    END;
-    -- TRY/CATCH
-    BEGIN TRY
-        SELECT @counter / @input AS division_result;
-    END TRY
-    BEGIN CATCH
-        PRINT 'Error caught';
-    END CATCH;
-    -- GOTO
-    IF @flag = 0
-        GOTO skip_section;
-    SELECT @result AS final_result, @counter AS final_counter, @name AS input_name;
-    skip_section:
-    PRINT 'validate_cache_proc completed';
-END;
-GO
-
--- psql
--- Turn off validation GUC after procedure creation (will be turned on again in verify for testing)
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = off;
-GO
-
--- tsql
+-- Test 22 (validate_cache_proc), Test 27 (corrupt_cache_test_func), and Test 28
+-- (version_mismatch) moved to antlr_parse_cache_local_regression_only-vu-prepare.mix
+-- since they require true Postgres superuser privileges (PGC_SUSET GUC and
+-- allow_system_table_mods). See BABEL-6879.
 -- Test 23: Procedure created with cache OFF, executed with cache ON in verify
 -- Tests that pltsql_update_func_cache_entry populates cache at EXEC time
 SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
@@ -474,59 +420,6 @@ CREATE PROCEDURE dbo.dep_rename_proc
 AS
 BEGIN
     SELECT id, val FROM dbo.dep_rename_table;
-END;
-GO
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
--- Test 27: Corrupt cache deserialization test
--- Create a simple function whose cache we'll corrupt in verify to test deserialization error handling
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
-CREATE FUNCTION dbo.corrupt_cache_test_func(@x INT)
-RETURNS INT
-AS
-BEGIN
-    RETURN @x + 100;
-END;
-GO
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
--- Test 28: Version mismatch — cached parse tree with a higher bbf_version
--- Create a simple procedure with cache ON so the parse tree and bbf_version get populated.
--- In verify, we'll update bbf_version to a higher value and exec — should skip cache and ANTLR re-parse.
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
-CREATE PROCEDURE dbo.version_mismatch
-    @val INT
-AS
-BEGIN
-    SELECT @val + 1 AS result;
 END;
 GO
 

--- a/test/JDBC/expected/BABEL-6037-vu-verify.out
+++ b/test/JDBC/expected/BABEL-6037-vu-verify.out
@@ -1556,53 +1556,10 @@ off
 
 
 
--- === Test 22: Parse cache validation (cached tree vs ANTLR comparison) ===
-PRINT '=== Test 22: Parse cache validation ===';
-GO
 
--- psql
--- Enable validation GUC at database level (SUSET - superuser only)
--- This will cause the next cache-hit EXEC to compare cached vs ANTLR trees
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = on;
-GO
-
--- tsql
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
--- Execute the validation procedure (triggers cached vs ANTLR comparison)
-EXEC dbo.validate_cache_proc @input = 0, @name = 'test';
-GO
-~~START~~
-int
-~~END~~
-
-~~START~~
-varchar#!#int#!#varchar
-small#!#0#!#test
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
--- psql
--- Disable validation GUC at database level
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = off;
-GO
-
-
--- tsql
+-- Test 22 (validate_cache_proc validation) moved to
+-- antlr_parse_cache_local_regression_only-vu-verify.mix — requires true
+-- Postgres superuser to set the SUSET validate_antlr_parse_cache GUC. See BABEL-6879.
 -- === Test 23: Proc created with cache OFF, executed with cache ON ===
 PRINT '=== Test 23: Cache populated at EXEC time ===';
 GO
@@ -1902,182 +1859,10 @@ off
 
 
 
--- Test 27: Error handling for cache deserialization failures at EXEC time
--- Test 27a: EXEC-time datums deserialization error
--- Test 27b: EXEC-time parse tree deserialization error
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
--- psql
--- Test 27a: Corrupt datums and test
-SET allow_system_table_mods = ON;
-UPDATE sys.babelfish_function_ext SET antlr_parse_cache_datums = '<>CORRUPTED_DATUMS'
-WHERE funcname = 'corrupt_cache_test_func' AND nspname = 'master_dbo';
-SET allow_system_table_mods = OFF;
-GO
-~~ROW COUNT: 1~~
-
-
--- tsql
--- Stats before datums deserialization error
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-~~START~~
-int
-0
-~~END~~
-
-
--- This should error
-SELECT dbo.corrupt_cache_test_func(5);
-GO
-~~START~~
-int
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: failed to restore cached ANTLR parse tree, unrecognized token: "<>CORRUPTED_DATUMS")~~
-
-
--- Stats after datums deserialization error (expects: errors=+1)
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-~~START~~
-int
-1
-~~END~~
-
-
--- psql
--- Test 27b: Corrupt parse tree and test
-SET allow_system_table_mods = ON;
-UPDATE sys.babelfish_function_ext SET antlr_parse_cache_tree = '<>CORRUPTED_TREE'
-WHERE funcname = 'corrupt_cache_test_func' AND nspname = 'master_dbo';
-SET allow_system_table_mods = OFF;
-GO
-~~ROW COUNT: 1~~
-
-
--- tsql
--- Stats before parse tree deserialization error
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-~~START~~
-int
-1
-~~END~~
-
-
--- This should error: "failed to restore cached ANTLR parse tree" (parse tree deserialization)
-SELECT dbo.corrupt_cache_test_func(5);
-GO
-~~START~~
-int
-~~ERROR (Code: 33557097)~~
-
-~~ERROR (Message: failed to restore cached ANTLR parse tree, unrecognized token: "<>CORRUPTED_TREE")~~
-
-
--- Stats after parse tree deserialization error (expects: errors=+1)
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-~~START~~
-int
-2
-~~END~~
-
-
--- After disabling cache, function should work normally via ANTLR
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
-SELECT dbo.corrupt_cache_test_func(5);
-GO
-~~START~~
-int
-105
-~~END~~
-
-
--- === Test 28: Version mismatch — cached tree with higher bbf_version ===
-PRINT '=== Test 28: Version mismatch (higher bbf_version) ===';
-GO
-
--- Verify cache is populated
-SELECT
-    CASE WHEN antlr_parse_cache_tree IS NOT NULL THEN 'CACHED' ELSE 'NOT CACHED' END AS cache_status
-FROM sys.babelfish_function_ext
-WHERE funcname = 'version_mismatch' AND nspname = 'master_dbo';
-GO
-~~START~~
-varchar
-CACHED
-~~END~~
-
-
--- psql
--- Update bbf_version to a higher version to simulate a version change
-SET allow_system_table_mods = ON;
-UPDATE sys.babelfish_function_ext SET antlr_parse_cache_bbf_version = '99.99.0'
-WHERE funcname = 'version_mismatch' AND nspname = 'master_dbo';
-SET allow_system_table_mods = OFF;
-GO
-~~ROW COUNT: 1~~
-
-
--- tsql
--- terminate-tsql-conn
-
--- tsql
--- New session: hash table is empty, do_compile runs, reads cache entry,
--- detects version mismatch (99.99.0 != current), skips cache, ANTLR re-parses.
--- Procedure should still execute correctly.
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-~~START~~
-text
-on
-~~END~~
-
-
-EXEC dbo.version_mismatch @val = 42;
-GO
-~~START~~
-int
-43
-~~END~~
-
-
--- Verify the cache was re-populated with the current bbf_version (not 99.99.0)
-SELECT
-    CASE WHEN antlr_parse_cache_tree IS NOT NULL THEN 'CACHED' ELSE 'NOT CACHED' END AS cache_status,
-    CASE WHEN antlr_parse_cache_bbf_version = '99.99.0' THEN 'STALE' ELSE 'CURRENT' END AS version_status
-FROM sys.babelfish_function_ext
-WHERE funcname = 'version_mismatch' AND nspname = 'master_dbo';
-GO
-~~START~~
-varchar#!#varchar
-CACHED#!#CURRENT
-~~END~~
-
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-~~START~~
-text
-off
-~~END~~
-
-
+-- Test 27 (corrupt_cache_test_func deserialization errors) and Test 28
+-- (version_mismatch bbf_version corruption) moved to
+-- antlr_parse_cache_local_regression_only-vu-verify.mix — both require
+-- allow_system_table_mods and true Postgres superuser. See BABEL-6879.
 -- === Test 29: DBCC CHECKIDENT procedure with cache on ===
 PRINT '=== Test 29: DBCC CHECKIDENT with cache on ===';
 GO
@@ -2098,7 +1883,7 @@ SELECT cache_writes, cache_errors FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int
-1#!#0
+10#!#0
 ~~END~~
 
 
@@ -2113,7 +1898,7 @@ SELECT cache_writes, cache_errors FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int
-2#!#0
+11#!#0
 ~~END~~
 
 
@@ -2138,7 +1923,7 @@ SELECT * FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int
-0#!#1#!#2#!#0#!#0
+5#!#9#!#11#!#5#!#0
 ~~END~~
 
 
@@ -2160,7 +1945,7 @@ SELECT * FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int
-0#!#1#!#2#!#0#!#0
+5#!#9#!#11#!#5#!#0
 ~~END~~
 
 
@@ -2203,7 +1988,7 @@ SELECT * FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int
-0#!#1#!#2#!#0#!#0
+5#!#9#!#11#!#5#!#0
 ~~END~~
 
 
@@ -2234,7 +2019,7 @@ SELECT * FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int
-0#!#1#!#2#!#0#!#0
+5#!#9#!#11#!#5#!#0
 ~~END~~
 
 
@@ -2264,7 +2049,7 @@ SELECT * FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int#!#int#!#int#!#int#!#int
-0#!#1#!#2#!#0#!#0
+5#!#9#!#11#!#5#!#0
 ~~END~~
 
 
@@ -2288,7 +2073,7 @@ SELECT cache_writes FROM sys.antlr_parse_cache_stats();
 GO
 ~~START~~
 int
-3
+12
 ~~END~~
 
 

--- a/test/JDBC/expected/BABEL-6037-vu-verify.out
+++ b/test/JDBC/expected/BABEL-6037-vu-verify.out
@@ -1557,9 +1557,6 @@ off
 
 
 
--- Test 22 (validate_cache_proc validation) moved to
--- antlr_parse_cache_local_regression_only-vu-verify.mix — requires true
--- Postgres superuser to set the SUSET validate_antlr_parse_cache GUC. See BABEL-6879.
 -- === Test 23: Proc created with cache OFF, executed with cache ON ===
 PRINT '=== Test 23: Cache populated at EXEC time ===';
 GO
@@ -1859,10 +1856,6 @@ off
 
 
 
--- Test 27 (corrupt_cache_test_func deserialization errors) and Test 28
--- (version_mismatch bbf_version corruption) moved to
--- antlr_parse_cache_local_regression_only-vu-verify.mix — both require
--- allow_system_table_mods and true Postgres superuser. See BABEL-6879.
 -- === Test 29: DBCC CHECKIDENT procedure with cache on ===
 PRINT '=== Test 29: DBCC CHECKIDENT with cache on ===';
 GO

--- a/test/JDBC/expected/antlr_parse_cache_version-vu-cleanup.out
+++ b/test/JDBC/expected/antlr_parse_cache_version-vu-cleanup.out
@@ -1,4 +1,4 @@
 
--- BABEL-6879: clean up the ANTLR parse-cache version-upgrade test.
+-- Clean up the ANTLR parse-cache version-upgrade test.
 DROP PROCEDURE IF EXISTS dbo.antlr_parse_cache_version_proc;
 GO

--- a/test/JDBC/expected/antlr_parse_cache_version-vu-cleanup.out
+++ b/test/JDBC/expected/antlr_parse_cache_version-vu-cleanup.out
@@ -1,0 +1,4 @@
+
+-- BABEL-6879: clean up the ANTLR parse-cache version-upgrade test.
+DROP PROCEDURE IF EXISTS dbo.antlr_parse_cache_version_proc;
+GO

--- a/test/JDBC/expected/antlr_parse_cache_version-vu-prepare.out
+++ b/test/JDBC/expected/antlr_parse_cache_version-vu-prepare.out
@@ -1,6 +1,6 @@
 -- tsql
 
--- BABEL-6879: prepare a cached procedure on the lower version.
+-- Prepare a cached procedure on the lower version.
 -- Verification intentionally checks only functional results so the expected
 -- output remains stable when the cached representation is invalidated by an upgrade.
 SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);

--- a/test/JDBC/expected/antlr_parse_cache_version-vu-prepare.out
+++ b/test/JDBC/expected/antlr_parse_cache_version-vu-prepare.out
@@ -1,0 +1,28 @@
+-- tsql
+
+-- BABEL-6879: prepare a cached procedure on the lower version.
+-- Verification intentionally checks only functional results so the expected
+-- output remains stable when the cached representation is invalidated by an upgrade.
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+CREATE PROCEDURE dbo.antlr_parse_cache_version_proc
+    @input INT
+AS
+BEGIN
+    SELECT @input + 1 AS result;
+END;
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/expected/antlr_parse_cache_version-vu-verify.out
+++ b/test/JDBC/expected/antlr_parse_cache_version-vu-verify.out
@@ -1,6 +1,6 @@
 -- tsql
 
--- BABEL-6879: execute a procedure cached by the lower version.
+-- Execute a procedure cached by the lower version.
 -- The first execution must reject the lower-version cache and reparse with ANTLR;
 -- the second execution verifies continued use in the same session.
 -- Expected upgrade stats: hits=0, misses=1, writes=1, evictions=0, errors=0.

--- a/test/JDBC/expected/antlr_parse_cache_version-vu-verify.out
+++ b/test/JDBC/expected/antlr_parse_cache_version-vu-verify.out
@@ -1,0 +1,45 @@
+-- tsql
+
+-- BABEL-6879: execute a procedure cached by the lower version.
+-- The first execution must reject the lower-version cache and reparse with ANTLR;
+-- the second execution verifies continued use in the same session.
+-- Expected upgrade stats: hits=0, misses=1, writes=1, evictions=0, errors=0.
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
+GO
+~~START~~
+text
+on
+~~END~~
+
+
+EXEC dbo.antlr_parse_cache_version_proc @input = 41;
+GO
+~~START~~
+int
+42
+~~END~~
+
+
+EXEC dbo.antlr_parse_cache_version_proc @input = 99;
+GO
+~~START~~
+int
+100
+~~END~~
+
+
+SELECT * FROM sys.antlr_parse_cache_stats();
+GO
+~~START~~
+int#!#int#!#int#!#int#!#int
+0#!#1#!#1#!#0#!#0
+~~END~~
+
+
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
+GO
+~~START~~
+text
+off
+~~END~~
+

--- a/test/JDBC/input/BABEL-6037-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-6037-vu-cleanup.sql
@@ -85,8 +85,7 @@ DROP PROCEDURE IF EXISTS dbo.perfunc_default_test;
 GO
 DROP PROCEDURE IF EXISTS test_cache_schema.perfunc_custom_schema;
 GO
-DROP PROCEDURE IF EXISTS dbo.validate_cache_proc;
-GO
+-- validate_cache_proc dropped in antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP PROCEDURE IF EXISTS dbo.nocache_create_proc;
 GO
 DROP PROCEDURE IF EXISTS dbo.overload_cache_proc;
@@ -105,10 +104,8 @@ DROP TABLE IF EXISTS dbo.dep_rename_table;
 GO
 DROP TABLE IF EXISTS dbo.dep_renamed_table;
 GO
-DROP FUNCTION IF EXISTS dbo.corrupt_cache_test_func;
-GO
-DROP PROCEDURE IF EXISTS dbo.version_mismatch;
-GO
+-- corrupt_cache_test_func and version_mismatch dropped in
+-- antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP USER IF EXISTS babel_6037_nonowner;
 GO
 DROP LOGIN babel_6037_nonowner;

--- a/test/JDBC/input/BABEL-6037-vu-cleanup.sql
+++ b/test/JDBC/input/BABEL-6037-vu-cleanup.sql
@@ -85,7 +85,6 @@ DROP PROCEDURE IF EXISTS dbo.perfunc_default_test;
 GO
 DROP PROCEDURE IF EXISTS test_cache_schema.perfunc_custom_schema;
 GO
--- validate_cache_proc dropped in antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP PROCEDURE IF EXISTS dbo.nocache_create_proc;
 GO
 DROP PROCEDURE IF EXISTS dbo.overload_cache_proc;
@@ -104,8 +103,6 @@ DROP TABLE IF EXISTS dbo.dep_rename_table;
 GO
 DROP TABLE IF EXISTS dbo.dep_renamed_table;
 GO
--- corrupt_cache_test_func and version_mismatch dropped in
--- antlr_parse_cache_local_regression_only-vu-cleanup.sql
 DROP USER IF EXISTS babel_6037_nonowner;
 GO
 DROP LOGIN babel_6037_nonowner;

--- a/test/JDBC/input/BABEL-6037-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-6037-vu-prepare.mix
@@ -328,65 +328,11 @@ BEGIN
 END;
 GO
 
--- psql
--- Test 22: Validation procedure with complex statement types
--- Used with pltsql_validate_antlr_parse_cache GUC to compare cached vs ANTLR trees
--- Note: validation GUC is SUSET (superuser only), so we set it at database level
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = on;
-GO
+-- Test 22 (validate_cache_proc), Test 27 (corrupt_cache_test_func), and Test 28
+-- (version_mismatch) moved to antlr_parse_cache_local_regression_only-vu-prepare.mix
+-- since they require true Postgres superuser privileges (PGC_SUSET GUC and
+-- allow_system_table_mods). See BABEL-6879.
 
--- tsql
-CREATE PROCEDURE dbo.validate_cache_proc
-    @input INT,
-    @name VARCHAR(50)
-AS
-BEGIN
-    DECLARE @counter INT;
-    DECLARE @result VARCHAR(100);
-    DECLARE @flag BIT;
-
-    SET @counter = 0;
-    SET @flag = 1;
-
-    -- IF/ELSE
-    IF @input > 10
-        SET @result = 'large';
-    ELSE
-        SET @result = 'small';
-
-    -- WHILE loop
-    WHILE @counter < @input
-    BEGIN
-        SET @counter = @counter + 1;
-        IF @counter = 5
-            BREAK;
-    END;
-
-    -- TRY/CATCH
-    BEGIN TRY
-        SELECT @counter / @input AS division_result;
-    END TRY
-    BEGIN CATCH
-        PRINT 'Error caught';
-    END CATCH;
-
-    -- GOTO
-    IF @flag = 0
-        GOTO skip_section;
-
-    SELECT @result AS final_result, @counter AS final_counter, @name AS input_name;
-
-    skip_section:
-    PRINT 'validate_cache_proc completed';
-END;
-GO
-
--- psql
--- Turn off validation GUC after procedure creation (will be turned on again in verify for testing)
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = off;
-GO
-
--- tsql
 -- Test 23: Procedure created with cache OFF, executed with cache ON in verify
 -- Tests that pltsql_update_func_cache_entry populates cache at EXEC time
 SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
@@ -450,39 +396,6 @@ CREATE PROCEDURE dbo.dep_rename_proc
 AS
 BEGIN
     SELECT id, val FROM dbo.dep_rename_table;
-END;
-GO
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-
--- Test 27: Corrupt cache deserialization test
--- Create a simple function whose cache we'll corrupt in verify to test deserialization error handling
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-
-CREATE FUNCTION dbo.corrupt_cache_test_func(@x INT)
-RETURNS INT
-AS
-BEGIN
-    RETURN @x + 100;
-END;
-GO
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-
--- Test 28: Version mismatch — cached parse tree with a higher bbf_version
--- Create a simple procedure with cache ON so the parse tree and bbf_version get populated.
--- In verify, we'll update bbf_version to a higher value and exec — should skip cache and ANTLR re-parse.
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-
-CREATE PROCEDURE dbo.version_mismatch
-    @val INT
-AS
-BEGIN
-    SELECT @val + 1 AS result;
 END;
 GO
 

--- a/test/JDBC/input/BABEL-6037-vu-prepare.mix
+++ b/test/JDBC/input/BABEL-6037-vu-prepare.mix
@@ -328,10 +328,6 @@ BEGIN
 END;
 GO
 
--- Test 22 (validate_cache_proc), Test 27 (corrupt_cache_test_func), and Test 28
--- (version_mismatch) moved to antlr_parse_cache_local_regression_only-vu-prepare.mix
--- since they require true Postgres superuser privileges (PGC_SUSET GUC and
--- allow_system_table_mods). See BABEL-6879.
 
 -- Test 23: Procedure created with cache OFF, executed with cache ON in verify
 -- Tests that pltsql_update_func_cache_entry populates cache at EXEC time

--- a/test/JDBC/input/BABEL-6037-vu-verify.mix
+++ b/test/JDBC/input/BABEL-6037-vu-verify.mix
@@ -866,34 +866,10 @@ SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
 GO
 
 
--- === Test 22: Parse cache validation (cached tree vs ANTLR comparison) ===
-PRINT '=== Test 22: Parse cache validation ===';
-GO
+-- Test 22 (validate_cache_proc validation) moved to
+-- antlr_parse_cache_local_regression_only-vu-verify.mix — requires true
+-- Postgres superuser to set the SUSET validate_antlr_parse_cache GUC. See BABEL-6879.
 
--- psql
--- Enable validation GUC at database level (SUSET - superuser only)
--- This will cause the next cache-hit EXEC to compare cached vs ANTLR trees
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = on;
-GO
-
--- tsql
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-
--- Execute the validation procedure (triggers cached vs ANTLR comparison)
-EXEC dbo.validate_cache_proc @input = 0, @name = 'test';
-GO
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-
--- psql
--- Disable validation GUC at database level
-ALTER DATABASE babelfish_db SET babelfishpg_tsql.validate_antlr_parse_cache = off;
-GO
-
-
--- tsql
 -- === Test 23: Proc created with cache OFF, executed with cache ON ===
 PRINT '=== Test 23: Cache populated at EXEC time ===';
 GO
@@ -1050,104 +1026,10 @@ GO
 SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
 GO
 
--- Test 27: Error handling for cache deserialization failures at EXEC time
--- Test 27a: EXEC-time datums deserialization error
--- Test 27b: EXEC-time parse tree deserialization error
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-
--- psql
--- Test 27a: Corrupt datums and test
-SET allow_system_table_mods = ON;
-UPDATE sys.babelfish_function_ext SET antlr_parse_cache_datums = '<>CORRUPTED_DATUMS'
-WHERE funcname = 'corrupt_cache_test_func' AND nspname = 'master_dbo';
-SET allow_system_table_mods = OFF;
-GO
-
--- tsql
--- Stats before datums deserialization error
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-
--- This should error
-SELECT dbo.corrupt_cache_test_func(5);
-GO
-
--- Stats after datums deserialization error (expects: errors=+1)
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-
--- psql
--- Test 27b: Corrupt parse tree and test
-SET allow_system_table_mods = ON;
-UPDATE sys.babelfish_function_ext SET antlr_parse_cache_tree = '<>CORRUPTED_TREE'
-WHERE funcname = 'corrupt_cache_test_func' AND nspname = 'master_dbo';
-SET allow_system_table_mods = OFF;
-GO
-
--- tsql
--- Stats before parse tree deserialization error
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-
--- This should error: "failed to restore cached ANTLR parse tree" (parse tree deserialization)
-SELECT dbo.corrupt_cache_test_func(5);
-GO
-
--- Stats after parse tree deserialization error (expects: errors=+1)
-SELECT cache_errors FROM sys.antlr_parse_cache_stats();
-GO
-
--- After disabling cache, function should work normally via ANTLR
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
-
-SELECT dbo.corrupt_cache_test_func(5);
-GO
-
--- === Test 28: Version mismatch — cached tree with higher bbf_version ===
-PRINT '=== Test 28: Version mismatch (higher bbf_version) ===';
-GO
-
--- Verify cache is populated
-SELECT
-    CASE WHEN antlr_parse_cache_tree IS NOT NULL THEN 'CACHED' ELSE 'NOT CACHED' END AS cache_status
-FROM sys.babelfish_function_ext
-WHERE funcname = 'version_mismatch' AND nspname = 'master_dbo';
-GO
-
--- psql
--- Update bbf_version to a higher version to simulate a version change
-SET allow_system_table_mods = ON;
-UPDATE sys.babelfish_function_ext SET antlr_parse_cache_bbf_version = '99.99.0'
-WHERE funcname = 'version_mismatch' AND nspname = 'master_dbo';
-SET allow_system_table_mods = OFF;
-GO
-
--- tsql
--- terminate-tsql-conn
-
--- tsql
--- New session: hash table is empty, do_compile runs, reads cache entry,
--- detects version mismatch (99.99.0 != current), skips cache, ANTLR re-parses.
--- Procedure should still execute correctly.
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
-GO
-
-EXEC dbo.version_mismatch @val = 42;
-GO
-
--- Verify the cache was re-populated with the current bbf_version (not 99.99.0)
-SELECT
-    CASE WHEN antlr_parse_cache_tree IS NOT NULL THEN 'CACHED' ELSE 'NOT CACHED' END AS cache_status,
-    CASE WHEN antlr_parse_cache_bbf_version = '99.99.0' THEN 'STALE' ELSE 'CURRENT' END AS version_status
-FROM sys.babelfish_function_ext
-WHERE funcname = 'version_mismatch' AND nspname = 'master_dbo';
-GO
-
-SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
-GO
+-- Test 27 (corrupt_cache_test_func deserialization errors) and Test 28
+-- (version_mismatch bbf_version corruption) moved to
+-- antlr_parse_cache_local_regression_only-vu-verify.mix — both require
+-- allow_system_table_mods and true Postgres superuser. See BABEL-6879.
 
 -- === Test 29: DBCC CHECKIDENT procedure with cache on ===
 PRINT '=== Test 29: DBCC CHECKIDENT with cache on ===';

--- a/test/JDBC/input/BABEL-6037-vu-verify.mix
+++ b/test/JDBC/input/BABEL-6037-vu-verify.mix
@@ -866,9 +866,6 @@ SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
 GO
 
 
--- Test 22 (validate_cache_proc validation) moved to
--- antlr_parse_cache_local_regression_only-vu-verify.mix — requires true
--- Postgres superuser to set the SUSET validate_antlr_parse_cache GUC. See BABEL-6879.
 
 -- === Test 23: Proc created with cache OFF, executed with cache ON ===
 PRINT '=== Test 23: Cache populated at EXEC time ===';
@@ -1026,10 +1023,6 @@ GO
 SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
 GO
 
--- Test 27 (corrupt_cache_test_func deserialization errors) and Test 28
--- (version_mismatch bbf_version corruption) moved to
--- antlr_parse_cache_local_regression_only-vu-verify.mix — both require
--- allow_system_table_mods and true Postgres superuser. See BABEL-6879.
 
 -- === Test 29: DBCC CHECKIDENT procedure with cache on ===
 PRINT '=== Test 29: DBCC CHECKIDENT with cache on ===';

--- a/test/JDBC/input/antlr_parse_cache_version-vu-cleanup.sql
+++ b/test/JDBC/input/antlr_parse_cache_version-vu-cleanup.sql
@@ -1,0 +1,4 @@
+-- BABEL-6879: clean up the ANTLR parse-cache version-upgrade test.
+
+DROP PROCEDURE IF EXISTS dbo.antlr_parse_cache_version_proc;
+GO

--- a/test/JDBC/input/antlr_parse_cache_version-vu-cleanup.sql
+++ b/test/JDBC/input/antlr_parse_cache_version-vu-cleanup.sql
@@ -1,4 +1,4 @@
--- BABEL-6879: clean up the ANTLR parse-cache version-upgrade test.
+-- Clean up the ANTLR parse-cache version-upgrade test.
 
 DROP PROCEDURE IF EXISTS dbo.antlr_parse_cache_version_proc;
 GO

--- a/test/JDBC/input/antlr_parse_cache_version-vu-prepare.mix
+++ b/test/JDBC/input/antlr_parse_cache_version-vu-prepare.mix
@@ -1,0 +1,18 @@
+-- tsql
+-- BABEL-6879: prepare a cached procedure on the lower version.
+-- Verification intentionally checks only functional results so the expected
+-- output remains stable when the cached representation is invalidated by an upgrade.
+
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
+GO
+
+CREATE PROCEDURE dbo.antlr_parse_cache_version_proc
+    @input INT
+AS
+BEGIN
+    SELECT @input + 1 AS result;
+END;
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
+GO

--- a/test/JDBC/input/antlr_parse_cache_version-vu-prepare.mix
+++ b/test/JDBC/input/antlr_parse_cache_version-vu-prepare.mix
@@ -1,5 +1,5 @@
 -- tsql
--- BABEL-6879: prepare a cached procedure on the lower version.
+-- Prepare a cached procedure on the lower version.
 -- Verification intentionally checks only functional results so the expected
 -- output remains stable when the cached representation is invalidated by an upgrade.
 

--- a/test/JDBC/input/antlr_parse_cache_version-vu-verify.mix
+++ b/test/JDBC/input/antlr_parse_cache_version-vu-verify.mix
@@ -1,0 +1,20 @@
+-- tsql
+-- BABEL-6879: execute a procedure cached by the lower version.
+-- The first execution must reject the lower-version cache and reparse with ANTLR;
+-- the second execution verifies continued use in the same session.
+-- Expected upgrade stats: hits=0, misses=1, writes=1, evictions=0, errors=0.
+
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'on', false);
+GO
+
+EXEC dbo.antlr_parse_cache_version_proc @input = 41;
+GO
+
+EXEC dbo.antlr_parse_cache_version_proc @input = 99;
+GO
+
+SELECT * FROM sys.antlr_parse_cache_stats();
+GO
+
+SELECT set_config('babelfishpg_tsql.enable_antlr_parse_cache', 'off', false);
+GO

--- a/test/JDBC/input/antlr_parse_cache_version-vu-verify.mix
+++ b/test/JDBC/input/antlr_parse_cache_version-vu-verify.mix
@@ -1,5 +1,5 @@
 -- tsql
--- BABEL-6879: execute a procedure cached by the lower version.
+-- Execute a procedure cached by the lower version.
 -- The first execution must reject the lower-version cache and reparse with ANTLR;
 -- the second execution verifies continued use in the same session.
 -- Expected upgrade stats: hits=0, misses=1, writes=1, evictions=0, errors=0.

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -790,3 +790,6 @@ ignore#!#money_aggregate-before-17_11-or-18_5-vu-cleanup
 ignore#!#numeric_money-before-17_11-or-18_5-vu-prepare
 ignore#!#numeric_money-before-17_11-or-18_5-vu-verify
 ignore#!#numeric_money-before-17_11-or-18_5-vu-cleanup
+ignore#!#antlr_parse_cache_version-vu-prepare
+ignore#!#antlr_parse_cache_version-vu-verify
+ignore#!#antlr_parse_cache_version-vu-cleanup

--- a/test/JDBC/upgrade/18_5/schedule
+++ b/test/JDBC/upgrade/18_5/schedule
@@ -689,8 +689,7 @@ forxml-path-elements
 xml_query
 forxml-auto
 BABEL-5264
-# [BABEL-6879] Temporarily ignored
-#BABEL-6037
+antlr_parse_cache_version
 babel_sqlvariant_coerce_type
 BABEL-login-db-long-identifiers
 BABEL-6813


### PR DESCRIPTION
### Description

This PR addresses two follow-up issues for persistent cross-session ANTLR parse-tree caching introduced in [#4547](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4547).

#### 1. Reset tokenizer state after node deserialization

This is a defensive cleanup to the cross-session ANTLR parse tree caching feature added in [#4547](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4547/commits), which introduced an extension-side node serializer/deserializer (`pltsql_stringToNode`) that uses the engine's tokenizer via the new `pg_strtok_init()` setter (added in the corresponding engine PR [#733](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/733/commits)).

Currently, `pltsql_stringToNode()` calls `pg_strtok_init(str)` on entry but does not reset the static `pg_strtok_ptr` before returning. Because the input string lives in a per-statement memory context that gets reset between SQL commands, the tokenizer pointer is left pointing into freed memory until the next caller of `stringToNode()` overwrites it. With this change, `pltsql_stringToNode()` resets `pg_strtok_ptr` to NULL before returning, matching PG's clean-state convention.

Raised during code review of the engine-side `pg_strtok_init()` addition. Behavior is unchanged in practice - the dangling pointer was never dereferenced because PG's `stringToNodeInternal()` always overwrites it with its own input before any read (verified via gdb on `pg_get_expr` / `pg_get_constraintdef` paths after a cached procedure EXEC). This is a defensive cleanup to remove the stale-pointer footgun for any future caller that might read the static directly.


#### 2. Split regular and version-upgrade cache tests

The parse-cache tests are separated by execution context:

- `BABEL-6037` retains integration-safe, same-version cache coverage. Tests requiring the `PGC_SUSET` validation GUC, `allow_system_table_mods`, or direct cache-catalog corruption were removed because they cannot run with integration-test privileges.
- A new upgrade-only `antlr_parse_cache_version` test prepares a cached procedure on the lower version and verifies it on the higher version. It confirms that the stale cache is rejected, the procedure is reparsed successfully, and the cache reports `0` hits, `1` miss, `1` write, `0` evictions, and `0` errors.
- The new test is excluded from regular JDBC execution and run only in the applicable version-upgrade path. The target upgrade script also creates the parse-cache catalog columns and SQL functions required by the test.

### Issues Resolved

- BABEL-6037
- BABEL-6879

### Test Scenarios Covered

- Ran the regular JDBC regression tests with the privileged/version-dependent cases removed from `BABEL-6037`.
- Added prepare, verify, and cleanup coverage for parse-cache invalidation across version upgrade.
- Verified functional execution after invalidation and the expected miss/write cache statistics.
- Verified with GDB that `pg_strtok_ptr` is reset to `NULL` after PL/tsql node deserialization.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).