### PR TITLE
Remove SELECT INTO row counts from before-prepare expected output

### DIFF
--- a/test/JDBC/expected/money_aggregate-before-17_5-or-16_9-vu-prepare.out
+++ b/test/JDBC/expected/money_aggregate-before-17_5-or-16_9-vu-prepare.out
@@ -39,40 +39,30 @@ SELECT MAX(Amount) AS MaxAmount
 INTO ResultTable1
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 2: MIN aggregation
 SELECT MIN(Amount) AS MinAmount
 INTO ResultTable2
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 3: AVG aggregation
 SELECT AVG(Amount) AS AvgAmount
 INTO ResultTable3
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 4: SUM aggregation
 SELECT SUM(Amount) AS TotalAmount
 INTO ResultTable4
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 5: COUNT aggregation (should remain as INT)
 SELECT COUNT(Amount) AS CountAmount
 INTO ResultTable5
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 6: Multiple aggregations in one query
 SELECT 
@@ -84,8 +74,6 @@ SELECT
 INTO ResultTable6
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 7: Aggregation with GROUP BY
 SELECT 
@@ -95,8 +83,6 @@ INTO ResultTable7
 FROM TestMoneyTable
 GROUP BY Description;
 GO
-~~ROW COUNT: 6~~
-
 
 -- Test Case 8: Aggregation with subquery
 SELECT MaxAmount
@@ -106,8 +92,6 @@ FROM (
     FROM TestMoneyTable
 ) AS Subquery;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 9: Aggregation with HAVING clause
 SELECT 
@@ -118,8 +102,6 @@ FROM TestMoneyTable
 GROUP BY Description
 HAVING MAX(Amount) > 200;
 GO
-~~ROW COUNT: 3~~
-
 
 -- Test Case 10: Aggregation with calculated MONEY column
 SELECT 
@@ -127,8 +109,6 @@ SELECT
 INTO ResultTable10
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Negative Test Case: Empty table
 CREATE TABLE EmptyMoneyTable (Amount MONEY);
@@ -138,8 +118,6 @@ SELECT MAX(Amount) AS MaxAmount
 INTO ResultTableEmpty
 FROM EmptyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Edge Test Case: Extreme values
 CREATE TABLE ExtremeMoneyTable (Amount MONEY);
@@ -156,8 +134,6 @@ SELECT MAX(Amount) AS MaxAmount, MIN(Amount) AS MinAmount
 INTO ResultTableExtreme
 FROM ExtremeMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Arbitrary Test Case: Mixing NULL and non-NULL values
 CREATE TABLE MixedNullMoneyTable (Amount MONEY);
@@ -177,8 +153,6 @@ SELECT
 INTO ResultTableMixedNull
 FROM MixedNullMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Edge Test Case: Aggregating calculated values that exceed MONEY range
 CREATE TABLE OverflowMoneyTable (Amount MONEY);
@@ -212,8 +186,6 @@ SELECT SUM(CAST(Amount AS MONEY)) AS TotalAmount
 INTO ResultTableNonMoney
 FROM NonMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Check Constraint Test
 CREATE TABLE CheckConstraintMoneyTable (
@@ -231,8 +203,6 @@ SELECT MAX(Amount) AS MaxCheckAmount
 INTO ResultTableCheck
 FROM CheckConstraintMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Complex Dependent Objects Test
 CREATE VIEW MoneyView AS SELECT MAX(Amount) as Amount FROM TestMoneyTable;
@@ -265,14 +235,10 @@ SELECT MAX(Amount) AS MaxViewAmount
 INTO ResultTableView
 FROM MoneyView;
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT GetTotalMoney() AS TotalFunctionAmount
 INTO ResultTableFunction;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Indexed View Test
 CREATE TABLE IndexedViewBaseTable (
@@ -298,8 +264,6 @@ SELECT MAX(Amount) AS MaxIndexedViewAmount
 INTO ResultTableIndexedView
 FROM IndexedMoneyView;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Currency Symbol Test Cases
 CREATE TABLE CurrencyMoneyTable (
@@ -327,22 +291,16 @@ SELECT MAX(Amount) AS MaxAmount
 INTO ResultTableCurrency1
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT MIN(Amount) AS MinAmount
 INTO ResultTableCurrency2
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT SUM(Amount) AS TotalAmount
 INTO ResultTableCurrency3
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test with mixed currency symbols in calculations
 SELECT 
@@ -353,5 +311,3 @@ SELECT
 INTO ResultTableCurrency4
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-

--- a/test/JDBC/expected/money_aggregate-before-17_6-or-16_10-vu-prepare.out
+++ b/test/JDBC/expected/money_aggregate-before-17_6-or-16_10-vu-prepare.out
@@ -39,40 +39,30 @@ SELECT MAX(Amount) AS MaxAmount
 INTO ResultTable1
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 2: MIN aggregation
 SELECT MIN(Amount) AS MinAmount
 INTO ResultTable2
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 3: AVG aggregation
 SELECT AVG(Amount) AS AvgAmount
 INTO ResultTable3
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 4: SUM aggregation
 SELECT SUM(Amount) AS TotalAmount
 INTO ResultTable4
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 5: COUNT aggregation (should remain as INT)
 SELECT COUNT(Amount) AS CountAmount
 INTO ResultTable5
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 6: Multiple aggregations in one query
 SELECT 
@@ -84,8 +74,6 @@ SELECT
 INTO ResultTable6
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 7: Aggregation with GROUP BY
 SELECT 
@@ -95,8 +83,6 @@ INTO ResultTable7
 FROM TestMoneyTable
 GROUP BY Description;
 GO
-~~ROW COUNT: 6~~
-
 
 -- Test Case 8: Aggregation with subquery
 SELECT MaxAmount
@@ -106,8 +92,6 @@ FROM (
     FROM TestMoneyTable
 ) AS Subquery;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test Case 9: Aggregation with HAVING clause
 SELECT 
@@ -118,8 +102,6 @@ FROM TestMoneyTable
 GROUP BY Description
 HAVING MAX(Amount) > 200;
 GO
-~~ROW COUNT: 3~~
-
 
 -- Test Case 10: Aggregation with calculated MONEY column
 SELECT 
@@ -127,8 +109,6 @@ SELECT
 INTO ResultTable10
 FROM TestMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Negative Test Case: Empty table
 CREATE TABLE EmptyMoneyTable (Amount MONEY);
@@ -138,8 +118,6 @@ SELECT MAX(Amount) AS MaxAmount
 INTO ResultTableEmpty
 FROM EmptyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Edge Test Case: Extreme values
 CREATE TABLE ExtremeMoneyTable (Amount MONEY);
@@ -156,8 +134,6 @@ SELECT MAX(Amount) AS MaxAmount, MIN(Amount) AS MinAmount
 INTO ResultTableExtreme
 FROM ExtremeMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Arbitrary Test Case: Mixing NULL and non-NULL values
 CREATE TABLE MixedNullMoneyTable (Amount MONEY);
@@ -177,8 +153,6 @@ SELECT
 INTO ResultTableMixedNull
 FROM MixedNullMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Edge Test Case: Aggregating calculated values that exceed MONEY range
 CREATE TABLE OverflowMoneyTable (Amount MONEY);
@@ -212,8 +186,6 @@ SELECT SUM(CAST(Amount AS MONEY)) AS TotalAmount
 INTO ResultTableNonMoney
 FROM NonMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Check Constraint Test
 CREATE TABLE CheckConstraintMoneyTable (
@@ -231,8 +203,6 @@ SELECT MAX(Amount) AS MaxCheckAmount
 INTO ResultTableCheck
 FROM CheckConstraintMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Complex Dependent Objects Test
 CREATE VIEW MoneyView AS SELECT MAX(Amount) as Amount FROM TestMoneyTable;
@@ -265,14 +235,10 @@ SELECT MAX(Amount) AS MaxViewAmount
 INTO ResultTableView
 FROM MoneyView;
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT GetTotalMoney() AS TotalFunctionAmount
 INTO ResultTableFunction;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Indexed View Test
 CREATE TABLE IndexedViewBaseTable (
@@ -298,8 +264,6 @@ SELECT MAX(Amount) AS MaxIndexedViewAmount
 INTO ResultTableIndexedView
 FROM IndexedMoneyView;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Currency Symbol Test Cases
 CREATE TABLE CurrencyMoneyTable (
@@ -327,22 +291,16 @@ SELECT MAX(Amount) AS MaxAmount
 INTO ResultTableCurrency1
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT MIN(Amount) AS MinAmount
 INTO ResultTableCurrency2
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 SELECT SUM(Amount) AS TotalAmount
 INTO ResultTableCurrency3
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-
 
 -- Test with mixed currency symbols in calculations
 SELECT 
@@ -353,5 +311,3 @@ SELECT
 INTO ResultTableCurrency4
 FROM CurrencyMoneyTable;
 GO
-~~ROW COUNT: 1~~
-


### PR DESCRIPTION
### Description
Removing SELECT INTO row counts from money_aggregate-before-17_5-or-16_9-vu-prepare.out and money_aggregate-before-17_6-or-16_10-vu-prepare.out which were added by commit https://github.com/babelfish-for-postgresql/babelfish_extensions/commit/45c57bf75fa3895207f360f15f9a40ad8ad01267
  
These before-*-vu-prepare files run on the older engine version which does not have the SELECT INTO row count feature, so they should not contain `~~ ROW COUNT ~~` lines for SELECT INTO statements.

### Issues Resolved

Task: https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/3203 / BABEL-540
Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).