### PR TITLE
Remove redundant atthasdef filter to fix cardinality misestimate (#4925)

### DIFF
--- a/contrib/babelfishpg_tsql/sql/sys_views.sql
+++ b/contrib/babelfishpg_tsql/sql/sys_views.sql
@@ -1263,7 +1263,7 @@ select CAST(('DF_' || tab.name || '_' || d.oid) as sys.sysname) as name
 from pg_catalog.pg_attrdef as d
 inner join pg_attribute a on a.attrelid = d.adrelid and d.adnum = a.attnum
 inner join sys.tables tab on d.adrelid = tab.object_id
-WHERE a.atthasdef = 't' and a.attgenerated = ''
+WHERE a.attgenerated = ''
 AND has_column_privilege(a.attrelid, a.attname, 'SELECT,INSERT,UPDATE,REFERENCES');
 GRANT SELECT ON sys.default_constraints TO PUBLIC;
 
@@ -1627,7 +1627,7 @@ inner join pg_class o on d.adrelid = o.oid
 inner join pg_namespace s on s.oid = o.relnamespace
 left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
 left join sys.shipped_objects_not_in_sys nis on nis.name = ('DF_' || o.relname || '_' || d.oid) and nis.schemaid = s.oid and nis.type = 'D'
-where a.atthasdef = 't' and a.attgenerated = ''
+where a.attgenerated = ''
 and (s.nspname = 'sys' or ext.nspname is not null)
 and has_column_privilege(a.attrelid, a.attname, 'SELECT,INSERT,UPDATE,REFERENCES')
 union all

--- a/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--5.7.0--5.8.0.sql
+++ b/contrib/babelfishpg_tsql/sql/upgrades/babelfishpg_tsql--5.7.0--5.8.0.sql
@@ -43,6 +43,430 @@ LANGUAGE plpgsql;
  * final behaviour.
  */
 
+create or replace view sys.all_objects as
+WITH tt_internal AS MATERIALIZED (
+  SELECT typrelid FROM sys.table_types_internal
+)
+select 
+    name collate sys.database_default
+  , cast (object_id as integer) 
+  , cast ( principal_id as integer)
+  , cast (schema_id as integer)
+  , cast (parent_object_id as integer)
+  , type collate sys.database_default
+  , cast (type_desc as sys.nvarchar(60))
+  , cast (create_date as sys.datetime)
+  , cast (modify_date as sys.datetime)
+  , is_ms_shipped
+  , cast (is_published as sys.bit)
+  , cast (is_schema_published as sys.bit)
+from
+(
+-- Currently for pg_class, pg_proc UNIONs, we separated user defined objects and system objects because the 
+-- optimiser will be able to make a better estimation of number of rows(in case the query contains a filter on 
+-- is_ms_shipped column) and in turn chooses a better query plan. 
+
+-- details of system tables
+select
+    t.relname::sys.sysname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'U'::char(2) as type
+  , 'USER_TABLE' as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 1::sys.bit as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class t inner join pg_namespace s on s.oid = t.relnamespace
+left join tt_internal tt on t.oid = tt.typrelid
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = t.relname and nis.schemaid = s.oid and nis.type = 'U'
+where t.relpersistence in ('p', 'u', 't')
+and t.relkind = 'r'
+and (s.nspname = 'sys' or (nis.name is not null and ext.nspname is not null))
+and tt.typrelid is null
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
+ 
+union all
+-- details of user defined tables
+select
+    t.relname::sys.sysname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'U'::char(2) as type
+  , 'USER_TABLE' as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0::sys.bit as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class t inner join pg_namespace s on s.oid = t.relnamespace
+left join tt_internal tt on t.oid = tt.typrelid
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = t.relname and nis.schemaid = s.oid and nis.type = 'U'
+where t.relpersistence in ('p', 'u', 't')
+and (t.relkind = 'r' or t.relkind = 'p')
+and t.relispartition = false
+and s.nspname <> 'sys' and nis.name is null
+and ext.nspname is not null
+and tt.typrelid is null
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
+ 
+union all
+-- details of system views
+select
+    t.relname::sys.sysname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'V'::char(2) as type
+  , 'VIEW'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 1::sys.bit as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class t inner join pg_namespace s on s.oid = t.relnamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = t.relname and nis.schemaid = s.oid and nis.type = 'V'
+where t.relkind = 'v'
+and (s.nspname = 'sys' or (nis.name is not null and ext.nspname is not null))
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
+union all
+-- Details of user defined views
+select
+    t.relname::sys.sysname as name
+  , t.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'V'::char(2) as type
+  , 'VIEW'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0::sys.bit as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class t inner join pg_namespace s on s.oid = t.relnamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = t.relname and nis.schemaid = s.oid and nis.type = 'V'
+where t.relkind = 'v'
+and s.nspname <> 'sys' and nis.name is null
+and ext.nspname is not null
+and has_table_privilege(t.oid, 'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,TRIGGER')
+union all
+-- details of user defined and system foreign key constraints
+select
+    c.conname::sys.sysname as name
+  , c.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , c.conrelid as parent_object_id
+  , 'F'::char(2) as type
+  , 'FOREIGN_KEY_CONSTRAINT'
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , CAST ((s.nspname = 'sys' or nis.name is not null) as sys.bit ) as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_constraint c
+inner join pg_namespace s on s.oid = c.connamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = c.conname and nis.schemaid = s.oid and nis.type = 'F'
+where 
+c.contype = 'f'
+and (s.nspname = 'sys' or ext.nspname is not null)
+union all
+-- details of user defined and system primary key constraints
+select
+    c.conname::sys.sysname as name
+  , c.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , c.conrelid as parent_object_id
+  , 'PK'::char(2) as type
+  , 'PRIMARY_KEY_CONSTRAINT' as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , CAST ((s.nspname = 'sys' or nis.name is not null) as sys.bit) as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_constraint c
+inner join pg_namespace s on s.oid = c.connamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = c.conname and nis.schemaid = s.oid and nis.type = 'PK'
+where 
+c.contype = 'p'
+and (s.nspname = 'sys' or ext.nspname is not null)
+union all
+-- details of system defined procedures
+select
+    p.proname::sys.sysname as name 
+  , case
+    when t.typname = 'trigger' then tr.oid else p.oid
+  end as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , cast (case when tr.tgrelid is not null 
+  		       then tr.tgrelid 
+  		       else 0 end as int) 
+    as parent_object_id
+  , case p.prokind
+      when 'p' then 'P'::char(2)
+      when 'a' then 'AF'::char(2)
+      else
+        case 
+          when t.typname = 'trigger'
+            then 'TR'::char(2)
+          when p.proretset then
+            case 
+              when t.typtype = 'c'
+                then 'TF'::char(2)
+              else 'IF'::char(2)
+            end
+          else 'FN'::char(2)
+        end
+    end as type
+  , case p.prokind
+      when 'p' then 'SQL_STORED_PROCEDURE'::varchar(60)
+      when 'a' then 'AGGREGATE_FUNCTION'::varchar(60)
+      else
+        case 
+          when t.typname = 'trigger'
+            then 'SQL_TRIGGER'::varchar(60)
+          when p.proretset then
+            case 
+              when t.typtype = 'c'
+                then 'SQL_TABLE_VALUED_FUNCTION'::varchar(60)
+              else 'SQL_INLINE_TABLE_VALUED_FUNCTION'::varchar(60)
+            end
+          else 'SQL_SCALAR_FUNCTION'::varchar(60)
+        end
+    end as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 1::sys.bit as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_proc p
+inner join pg_namespace s on s.oid = p.pronamespace
+inner join pg_catalog.pg_type t on t.oid = p.prorettype
+left join pg_trigger tr on tr.tgfoid = p.oid
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = p.proname and nis.schemaid = s.oid 
+and nis.type = (case p.prokind
+      when 'p' then 'P'::char(2)
+      when 'a' then 'AF'::char(2)
+      else
+        case 
+          when t.typname = 'trigger'
+            then 'TR'::char(2)
+          when p.proretset then
+            case 
+              when t.typtype = 'c'
+                then 'TF'::char(2)
+              else 'IF'::char(2)
+            end
+          else 'FN'::char(2)
+        end
+    end)
+where (s.nspname = 'sys' or (nis.name is not null and ext.nspname is not null))
+and has_function_privilege(p.oid, 'EXECUTE')
+and p.proname != 'pltsql_call_handler'
+ 
+union all
+-- details of user defined procedures
+select
+    p.proname::sys.sysname as name 
+  , case
+      when t.typname = 'trigger' then tr.oid else p.oid
+    end as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , cast (case when tr.tgrelid is not null 
+  		       then tr.tgrelid 
+  		       else 0 end as int) 
+    as parent_object_id
+  , case p.prokind
+      when 'p' then 'P'::char(2)
+      when 'a' then 'AF'::char(2)
+      else
+        case 
+          when t.typname = 'trigger'
+            then 'TR'::char(2)
+          when p.proretset then
+            case 
+              when t.typtype = 'c'
+                then 'TF'::char(2)
+              else 'IF'::char(2)
+            end
+          else 'FN'::char(2)
+        end
+    end as type
+  , case p.prokind
+      when 'p' then 'SQL_STORED_PROCEDURE'::varchar(60)
+      when 'a' then 'AGGREGATE_FUNCTION'::varchar(60)
+      else
+        case 
+          when t.typname = 'trigger'
+            then 'SQL_TRIGGER'::varchar(60)
+          when p.proretset then
+            case 
+              when t.typtype = 'c'
+                then 'SQL_TABLE_VALUED_FUNCTION'::varchar(60)
+              else 'SQL_INLINE_TABLE_VALUED_FUNCTION'::varchar(60)
+            end
+          else 'SQL_SCALAR_FUNCTION'::varchar(60)
+        end
+    end as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , 0::sys.bit as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_proc p
+inner join pg_namespace s on s.oid = p.pronamespace
+inner join pg_catalog.pg_type t on t.oid = p.prorettype
+left join pg_trigger tr on tr.tgfoid = p.oid
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = p.proname and nis.schemaid = s.oid 
+and nis.type = (case p.prokind
+      when 'p' then 'P'::char(2)
+      when 'a' then 'AF'::char(2)
+      else
+        case 
+          when t.typname = 'trigger'
+            then 'TR'::char(2)
+          when p.proretset then
+            case 
+              when t.typtype = 'c'
+                then 'TF'::char(2)
+              else 'IF'::char(2)
+            end
+          else 'FN'::char(2)
+        end
+    end)
+where s.nspname <> 'sys' and nis.name is null
+and ext.nspname is not null
+and has_function_privilege(p.oid, 'EXECUTE')
+ 
+union all
+-- details of all default constraints
+select
+    ('DF_' || o.relname || '_' || d.oid)::sys.sysname as name
+  , d.oid as object_id
+  , null::int as principal_id
+  , o.relnamespace as schema_id
+  , d.adrelid as parent_object_id
+  , 'D'::char(2) as type
+  , 'DEFAULT_CONSTRAINT'::sys.nvarchar(60) AS type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , CAST ((s.nspname = 'sys' or nis.name is not null) as sys.bit) as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_catalog.pg_attrdef d
+inner join pg_attribute a on a.attrelid = d.adrelid and d.adnum = a.attnum
+inner join pg_class o on d.adrelid = o.oid
+inner join pg_namespace s on s.oid = o.relnamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = ('DF_' || o.relname || '_' || d.oid) and nis.schemaid = s.oid and nis.type = 'D'
+where a.attgenerated = ''
+and (s.nspname = 'sys' or ext.nspname is not null)
+and has_column_privilege(a.attrelid, a.attname, 'SELECT,INSERT,UPDATE,REFERENCES')
+union all
+-- details of all check constraints
+select
+    c.conname::sys.sysname
+  , c.oid::integer as object_id
+  , NULL::integer as principal_id 
+  , s.oid as schema_id
+  , c.conrelid::integer as parent_object_id
+  , 'C'::char(2) as type
+  , 'CHECK_CONSTRAINT'::sys.nvarchar(60) as type_desc
+  , null::sys.datetime as create_date
+  , null::sys.datetime as modify_date
+  , CAST ((s.nspname = 'sys' or nis.name is not null) as sys.bit) as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_catalog.pg_constraint as c
+inner join pg_namespace s on s.oid = c.connamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = c.conname and nis.schemaid = s.oid and nis.type = 'C'
+where 
+c.contype = 'c' and c.conrelid != 0
+and (s.nspname = 'sys' or ext.nspname is not null)
+union all
+-- details of user defined and system defined sequence objects
+select
+  p.relname::sys.sysname as name
+  , p.oid as object_id
+  , null::integer as principal_id
+  , s.oid as schema_id
+  , 0 as parent_object_id
+  , 'SO'::char(2) as type
+  , 'SEQUENCE_OBJECT'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , CAST ((s.nspname = 'sys' or nis.name is not null) as sys.bit ) as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from pg_class p
+inner join pg_namespace s on s.oid = p.relnamespace
+left join sys.babelfish_namespace_ext ext on (s.nspname = ext.nspname and ext.dbid = sys.db_id())
+left join sys.shipped_objects_not_in_sys nis on nis.name = p.relname and nis.schemaid = s.oid and nis.type = 'SO'
+where p.relkind = 'S'
+and (s.nspname = 'sys' or ext.nspname is not null)
+union all
+-- details of user defined table types
+select
+    ('TT_' || tt.name || '_' || tt.type_table_object_id)::sys.sysname as name
+  , tt.type_table_object_id as object_id
+  , tt.principal_id as principal_id
+  , tt.schema_id as schema_id
+  , 0 as parent_object_id
+  , 'TT'::char(2) as type
+  , 'TABLE_TYPE'::varchar(60) as type_desc
+  , null::timestamp as create_date
+  , null::timestamp as modify_date
+  , CAST ((tt.schema_id::regnamespace::text = 'sys' or nis.name is not null) as sys.bit ) as is_ms_shipped
+  , 0 as is_published
+  , 0 as is_schema_published
+from sys.table_types tt
+left join sys.shipped_objects_not_in_sys nis on nis.name = ('TT_' || tt.name || '_' || tt.type_table_object_id)::name and nis.schemaid = tt.schema_id and nis.type = 'TT'
+) ot;
+GRANT SELECT ON sys.all_objects TO PUBLIC;
+
+create or replace view sys.default_constraints
+AS
+select CAST(('DF_' || tab.name || '_' || d.oid) as sys.sysname) as name
+  , CAST(d.oid as int) as object_id
+  , CAST(null as int) as principal_id
+  , CAST(tab.schema_id as int) as schema_id
+  , CAST(d.adrelid as int) as parent_object_id
+  , CAST('D' as sys.bpchar(2)) as type
+  , CAST('DEFAULT_CONSTRAINT' as sys.nvarchar(60)) AS type_desc
+  , CAST(null as sys.datetime) as create_date
+  , CAST(null as sys.datetime) as modified_date
+  , CAST(0 as sys.bit) as is_ms_shipped
+  , CAST(0 as sys.bit) as is_published
+  , CAST(0 as sys.bit) as is_schema_published
+  , CAST(d.adnum as int) as parent_column_id
+  , CAST(tsql_get_expr(d.adbin, d.adrelid) as sys.nvarchar) as definition
+  , CAST(1 as sys.bit) as is_system_named
+from pg_catalog.pg_attrdef as d
+inner join pg_attribute a on a.attrelid = d.adrelid and d.adnum = a.attnum
+inner join sys.tables tab on d.adrelid = tab.object_id
+WHERE a.attgenerated = ''
+AND has_column_privilege(a.attrelid, a.attname, 'SELECT,INSERT,UPDATE,REFERENCES');
+GRANT SELECT ON sys.default_constraints TO PUBLIC;
+
 CREATE OR REPLACE FUNCTION sys.babelfish_update_server_collation_name() RETURNS VOID
 LANGUAGE C
 AS 'babelfishpg_common', 'babelfish_update_server_collation_name';

--- a/test/JDBC/expected/db_collation/sys-default_constraints-vu-verify.out
+++ b/test/JDBC/expected/db_collation/sys-default_constraints-vu-verify.out
@@ -36,3 +36,97 @@ int
 15
 ~~END~~
 
+
+-- Verify generated columns do not appear as default constraints (attgenerated filter working)
+CREATE TABLE sys_default_constraints_vu_verify_generated (a INT DEFAULT 5, b AS (a + 1), c INT DEFAULT 10);
+GO
+
+-- Only columns with actual defaults (a, c) should appear, not generated column (b)
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated');
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Verify same count in sys.all_objects for this table
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated');
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Verify default constraints appear correctly in sys.all_objects with correct type
+SELECT type, type_desc FROM sys.all_objects
+WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated') AND type = 'D'
+ORDER BY name;
+GO
+~~START~~
+char#!#nvarchar
+D #!#DEFAULT_CONSTRAINT
+D #!#DEFAULT_CONSTRAINT
+~~END~~
+
+
+-- Verify table with all columns having named defaults shows correct count
+CREATE TABLE sys_default_constraints_vu_verify_alldef (a INT CONSTRAINT DF_alldef_a DEFAULT 1, b INT CONSTRAINT DF_alldef_b DEFAULT 2, c VARCHAR(10) CONSTRAINT DF_alldef_c DEFAULT 'abc');
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_alldef');
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_alldef');
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Verify table with NO defaults shows zero constraints
+CREATE TABLE sys_default_constraints_vu_verify_nodef (a INT, b INT, c VARCHAR(10));
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Verify add default - constraint appears in both views
+ALTER TABLE sys_default_constraints_vu_verify_nodef ADD CONSTRAINT DF_nodef_a DEFAULT 99 FOR a;
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+1
+~~END~~
+

--- a/test/JDBC/expected/sys-default_constraints-vu-cleanup.out
+++ b/test/JDBC/expected/sys-default_constraints-vu-cleanup.out
@@ -3,3 +3,12 @@ GO
 
 DROP TABLE IF EXISTS sys_default_definitions_vu_prepare
 GO
+
+DROP TABLE IF EXISTS sys_default_constraints_vu_verify_generated
+GO
+
+DROP TABLE IF EXISTS sys_default_constraints_vu_verify_alldef
+GO
+
+DROP TABLE IF EXISTS sys_default_constraints_vu_verify_nodef
+GO

--- a/test/JDBC/expected/sys-default_constraints-vu-verify.out
+++ b/test/JDBC/expected/sys-default_constraints-vu-verify.out
@@ -36,3 +36,97 @@ int
 15
 ~~END~~
 
+
+-- Verify generated columns do not appear as default constraints (attgenerated filter working)
+CREATE TABLE sys_default_constraints_vu_verify_generated (a INT DEFAULT 5, b AS (a + 1), c INT DEFAULT 10);
+GO
+
+-- Only columns with actual defaults (a, c) should appear, not generated column (b)
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated');
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Verify same count in sys.all_objects for this table
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated');
+GO
+~~START~~
+int
+2
+~~END~~
+
+
+-- Verify default constraints appear correctly in sys.all_objects with correct type
+SELECT type, type_desc FROM sys.all_objects
+WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated') AND type = 'D'
+ORDER BY name;
+GO
+~~START~~
+char#!#nvarchar
+D #!#DEFAULT_CONSTRAINT
+D #!#DEFAULT_CONSTRAINT
+~~END~~
+
+
+-- Verify table with all columns having named defaults shows correct count
+CREATE TABLE sys_default_constraints_vu_verify_alldef (a INT CONSTRAINT DF_alldef_a DEFAULT 1, b INT CONSTRAINT DF_alldef_b DEFAULT 2, c VARCHAR(10) CONSTRAINT DF_alldef_c DEFAULT 'abc');
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_alldef');
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_alldef');
+GO
+~~START~~
+int
+3
+~~END~~
+
+
+-- Verify table with NO defaults shows zero constraints
+CREATE TABLE sys_default_constraints_vu_verify_nodef (a INT, b INT, c VARCHAR(10));
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+0
+~~END~~
+
+
+-- Verify add default - constraint appears in both views
+ALTER TABLE sys_default_constraints_vu_verify_nodef ADD CONSTRAINT DF_nodef_a DEFAULT 99 FOR a;
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+1
+~~END~~
+
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+~~START~~
+int
+1
+~~END~~
+

--- a/test/JDBC/input/views/sys-default_constraints-vu-cleanup.sql
+++ b/test/JDBC/input/views/sys-default_constraints-vu-cleanup.sql
@@ -3,3 +3,12 @@ GO
 
 DROP TABLE IF EXISTS sys_default_definitions_vu_prepare
 GO
+
+DROP TABLE IF EXISTS sys_default_constraints_vu_verify_generated
+GO
+
+DROP TABLE IF EXISTS sys_default_constraints_vu_verify_alldef
+GO
+
+DROP TABLE IF EXISTS sys_default_constraints_vu_verify_nodef
+GO

--- a/test/JDBC/input/views/sys-default_constraints-vu-verify.sql
+++ b/test/JDBC/input/views/sys-default_constraints-vu-verify.sql
@@ -12,3 +12,51 @@ GO
 
 SELECT COUNT(*) FROM sys.all_columns WHERE object_id = object_id('sys.default_constraints');
 GO
+
+-- Verify generated columns do not appear as default constraints (attgenerated filter working)
+CREATE TABLE sys_default_constraints_vu_verify_generated (a INT DEFAULT 5, b AS (a + 1), c INT DEFAULT 10);
+GO
+
+-- Only columns with actual defaults (a, c) should appear, not generated column (b)
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated');
+GO
+
+-- Verify same count in sys.all_objects for this table
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated');
+GO
+
+-- Verify default constraints appear correctly in sys.all_objects with correct type
+SELECT type, type_desc FROM sys.all_objects
+WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_generated') AND type = 'D'
+ORDER BY name;
+GO
+
+-- Verify table with all columns having named defaults shows correct count
+CREATE TABLE sys_default_constraints_vu_verify_alldef (a INT CONSTRAINT DF_alldef_a DEFAULT 1, b INT CONSTRAINT DF_alldef_b DEFAULT 2, c VARCHAR(10) CONSTRAINT DF_alldef_c DEFAULT 'abc');
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_alldef');
+GO
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_alldef');
+GO
+
+-- Verify table with NO defaults shows zero constraints
+CREATE TABLE sys_default_constraints_vu_verify_nodef (a INT, b INT, c VARCHAR(10));
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+
+-- Verify add default - constraint appears in both views
+ALTER TABLE sys_default_constraints_vu_verify_nodef ADD CONSTRAINT DF_nodef_a DEFAULT 99 FOR a;
+GO
+
+SELECT COUNT(*) FROM sys.default_constraints WHERE parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO
+
+SELECT COUNT(*) FROM sys.all_objects WHERE type = 'D' AND parent_object_id = OBJECT_ID('sys_default_constraints_vu_verify_nodef');
+GO


### PR DESCRIPTION
### Description

Removing the redundant `atthasdef = 't'` predicate from the Default Constraints branch of sys.all_objects and sys.default_constraints. The pg_attrdef join already guarantees `atthasdef = true` for every joined row, making this filter a no-op at execution time. However, its presence causes the PostgreSQL planner to apply a wrong selectivity estimate (global frequency of atthasdef = true instead of the true 100% post-join frequency), leading to severe cardinality underestimates and catastrophic plan choices under certain conditions.
  
The planner cannot detect that the atthasdef = 't' filter is correlated with the pg_attrdef join. It looks up global statistics for atthasdef on pg_attribute (where only a small fraction of all columns have defaults) and applies this fraction to the post-join result, where the true selectivity is 100%. This produces a ~400× cardinality underestimate, compounded by the has_column_privilege() default selectivity. Under specific namespace distributions, this triggers catastrophic Merge Join choices with hundreds of millions of rows filtered.

Cherry-picked from : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4925

#### Proof of Redundancy
  
```
  SELECT count(*) FROM pg_attrdef d
  JOIN pg_attribute a ON a.attrelid = d.adrelid AND d.adnum = a.attnum
  WHERE a.atthasdef = false;
  -- Result: 0
```
  
This is guaranteed by PostgreSQL's StoreAttrDefault() (sets `atthasdef = true` when inserting into pg_attrdef) and RemoveAttrDefaultById() (sets `atthasdef = false` when deleting from `pg_attrdef`) 

#### Estimate Improvement

 | PG Version | Namespaces | Before Fix (est) | After Fix (est) | Actual |
  |------------|------------|------------------|-----------------|--------|
  | 17.10      | 576        | 11               | 1626           | 5009  |
  | 17.11      | 76         | 11               | 1684           | 5009  |
  | 17.11      | 576        | 13               | 1657           | 5009  |
  | 18.5       | 76         | 12               | 1668           | 5009  |

Remaining 3× gap is from has_column_privilege() default selectivity

On PG 17.x with 500+ namespaces, the misestimate causes the planner to choose Merge Join with hundreds of millions of rows removed by join filter. After the fix, the planner correctly chooses Nested Loop, eliminating the catastrophic execution path.
  
PG 18 mitigates the worst-case via multi-column merge conditions with incremental sort, but the misestimate and suboptimal plan choice persist without the fix.

### Issues Resolved

Task: BABEL-6458

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)


### Test Scenarios Covered ###
* **Use case based -** Yes


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).