### PR TITLE
Fix NULL pointer dereference in is_babelfish_role()

### DIFF
--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -960,6 +960,9 @@ is_babelfish_role(const char *role)
 	int			i;
 	bool			is_babelfish_login = false;
 
+	if (role == NULL)
+		return false;
+	
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
 	securityadmin = get_role_oid(BABELFISH_SECURITYADMIN, true);  /* missing OK */
@@ -1281,9 +1284,14 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 	{
 		RoleSpec   *rolespec = lfirst_node(RoleSpec, item);
 		Oid			roleid;
+		const char *rolename;
 
 		roleid = get_rolespec_oid(rolespec, false);
-		if (OidIsValid(roleid) && is_babelfish_role(rolespec->rolename))
+		if (!OidIsValid(roleid))
+			continue;
+
+		rolename = GetUserNameFromId(roleid, true);
+		if (is_babelfish_role(rolename))
 			check_babelfish_alterrole_restictions(false);
 	}
 

--- a/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
+++ b/contrib/babelfishpg_tds/src/backend/tds/tdsutils.c
@@ -962,7 +962,7 @@ is_babelfish_role(const char *role)
 
 	if (role == NULL)
 		return false;
-	
+
 	sysadmin_oid = get_role_oid(BABELFISH_SYSADMIN, true);	/* missing OK */
 	role_oid = get_role_oid(role, true);	/* missing OK */
 	securityadmin = get_role_oid(BABELFISH_SECURITYADMIN, true);  /* missing OK */
@@ -1293,6 +1293,8 @@ handle_grant_role(GrantRoleStmt *grant_stmt)
 		rolename = GetUserNameFromId(roleid, true);
 		if (is_babelfish_role(rolename))
 			check_babelfish_alterrole_restictions(false);
+		if (rolename)
+			pfree((char *) rolename);
 	}
 
 	return true;

--- a/test/JDBC/expected/grant-role-current-user.out
+++ b/test/JDBC/expected/grant-role-current-user.out
@@ -99,6 +99,51 @@ GO
     Server SQLState: 42501)~~
 
 
+-- terminate-psql-conn user=babel_6839_pg_user password=12345678
+
+-- tsql
+-- Test 11: GRANT pg_role TO CURRENT_USER where current_user is a babelfish role
+-- Create a babelfish login from the TSQL endpoint
+CREATE LOGIN babel_6839_bbf_user WITH PASSWORD = '12345678';
+GO
+
+-- psql user=babel_6839_bbf_user password=12345678
+-- Test 11: GRANT non-babelfish role TO CURRENT_USER (babelfish role) should be blocked
+GRANT babel_6839_test_role TO CURRENT_USER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=babel_6839_bbf_user password=12345678
+-- Test 12: GRANT non-babelfish role TO CURRENT_ROLE (babelfish role) should be blocked
+GRANT babel_6839_test_role TO CURRENT_ROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=babel_6839_bbf_user password=12345678
+-- Test 13: GRANT non-babelfish role TO SESSION_USER (babelfish role) should be blocked
+GRANT babel_6839_test_role TO SESSION_USER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- terminate-psql-conn user=babel_6839_bbf_user password=12345678
+
+-- tsql
+-- Cleanup babelfish login
+DROP LOGIN babel_6839_bbf_user;
+GO
+
 -- psql
 -- Cleanup
 DROP USER babel_6839_pg_user;

--- a/test/JDBC/expected/grant-role-current-user.out
+++ b/test/JDBC/expected/grant-role-current-user.out
@@ -1,0 +1,108 @@
+-- psql
+-- BABEL-6839: NULL pointer dereference in is_babelfish_role() when
+-- GRANT/REVOKE <role> TO/FROM CURRENT_USER, CURRENT_ROLE, SESSION_USER
+-- is executed from the PostgreSQL endpoint by a non-superuser.
+-- Setup: create a non-superuser PG role and a plain role for testing
+CREATE USER babel_6839_pg_user WITH LOGIN CREATEROLE PASSWORD '12345678' INHERIT;
+GO
+
+CREATE ROLE babel_6839_test_role;
+GO
+
+GRANT babel_6839_test_role TO babel_6839_pg_user WITH ADMIN OPTION;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 1: GRANT role TO CURRENT_USER should not crash (previously caused SIGSEGV)
+GRANT babel_6839_test_role TO CURRENT_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 2: GRANT role TO CURRENT_ROLE should not crash
+GRANT babel_6839_test_role TO CURRENT_ROLE;
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: role "babel_6839_pg_user" has already been granted membership in role "babel_6839_test_role" by role "babel_6839_pg_user"  Server SQLState: 00000)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 3: GRANT role TO SESSION_USER should not crash
+GRANT babel_6839_test_role TO SESSION_USER;
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: role "babel_6839_pg_user" has already been granted membership in role "babel_6839_test_role" by role "babel_6839_pg_user"  Server SQLState: 00000)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 4: REVOKE role FROM CURRENT_USER should not crash
+REVOKE babel_6839_test_role FROM CURRENT_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 5: REVOKE role FROM CURRENT_ROLE should not crash
+REVOKE babel_6839_test_role FROM CURRENT_ROLE;
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: role "babel_6839_pg_user" has not been granted membership in role "babel_6839_test_role" by role "babel_6839_pg_user"  Server SQLState: 01000)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 6: REVOKE role FROM SESSION_USER should not crash
+REVOKE babel_6839_test_role FROM SESSION_USER;
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: role "babel_6839_pg_user" has not been granted membership in role "babel_6839_test_role" by role "babel_6839_pg_user"  Server SQLState: 01000)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 7: GRANT babelfish role (sysadmin) TO CURRENT_USER should be blocked
+-- with proper error, not crash
+GRANT sysadmin TO CURRENT_USER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 8: GRANT babelfish role (sysadmin) TO CURRENT_ROLE should be blocked
+GRANT sysadmin TO CURRENT_ROLE;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 9: GRANT babelfish role (sysadmin) TO SESSION_USER should be blocked
+GRANT sysadmin TO SESSION_USER;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 10: GRANT with literal name still enforces Babelfish restriction
+GRANT sysadmin TO babel_6839_pg_user;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: Babelfish-created logins/users/roles cannot be altered outside of a Babelfish session
+    Server SQLState: 42501)~~
+
+
+-- psql
+-- Cleanup
+DROP USER babel_6839_pg_user;
+GO
+
+DROP ROLE babel_6839_test_role;
+GO

--- a/test/JDBC/input/grant-role-current-user.mix
+++ b/test/JDBC/input/grant-role-current-user.mix
@@ -1,0 +1,72 @@
+-- psql
+-- BABEL-6839: NULL pointer dereference in is_babelfish_role() when
+-- GRANT/REVOKE <role> TO/FROM CURRENT_USER, CURRENT_ROLE, SESSION_USER
+-- is executed from the PostgreSQL endpoint by a non-superuser.
+-- Setup: create a non-superuser PG role and a plain role for testing
+CREATE USER babel_6839_pg_user WITH LOGIN CREATEROLE PASSWORD '12345678' INHERIT;
+GO
+
+CREATE ROLE babel_6839_test_role;
+GO
+
+GRANT babel_6839_test_role TO babel_6839_pg_user WITH ADMIN OPTION;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 1: GRANT role TO CURRENT_USER should not crash (previously caused SIGSEGV)
+GRANT babel_6839_test_role TO CURRENT_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 2: GRANT role TO CURRENT_ROLE should not crash
+GRANT babel_6839_test_role TO CURRENT_ROLE;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 3: GRANT role TO SESSION_USER should not crash
+GRANT babel_6839_test_role TO SESSION_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 4: REVOKE role FROM CURRENT_USER should not crash
+REVOKE babel_6839_test_role FROM CURRENT_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 5: REVOKE role FROM CURRENT_ROLE should not crash
+REVOKE babel_6839_test_role FROM CURRENT_ROLE;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 6: REVOKE role FROM SESSION_USER should not crash
+REVOKE babel_6839_test_role FROM SESSION_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 7: GRANT babelfish role (sysadmin) TO CURRENT_USER should be blocked
+-- with proper error, not crash
+GRANT sysadmin TO CURRENT_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 8: GRANT babelfish role (sysadmin) TO CURRENT_ROLE should be blocked
+GRANT sysadmin TO CURRENT_ROLE;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 9: GRANT babelfish role (sysadmin) TO SESSION_USER should be blocked
+GRANT sysadmin TO SESSION_USER;
+GO
+
+-- psql user=babel_6839_pg_user password=12345678
+-- Test 10: GRANT with literal name still enforces Babelfish restriction
+GRANT sysadmin TO babel_6839_pg_user;
+GO
+
+-- psql
+-- Cleanup
+DROP USER babel_6839_pg_user;
+GO
+
+DROP ROLE babel_6839_test_role;
+GO

--- a/test/JDBC/input/grant-role-current-user.mix
+++ b/test/JDBC/input/grant-role-current-user.mix
@@ -63,8 +63,38 @@ GO
 GRANT sysadmin TO babel_6839_pg_user;
 GO
 
--- psql
+-- terminate-psql-conn user=babel_6839_pg_user password=12345678
+
+-- tsql
+-- Test 11: GRANT pg_role TO CURRENT_USER where current_user is a babelfish role
+-- Create a babelfish login from the TSQL endpoint
+CREATE LOGIN babel_6839_bbf_user WITH PASSWORD = '12345678';
+GO
+
+-- psql user=babel_6839_bbf_user password=12345678
+-- Test 11: GRANT non-babelfish role TO CURRENT_USER (babelfish role) should be blocked
+GRANT babel_6839_test_role TO CURRENT_USER;
+GO
+
+-- psql user=babel_6839_bbf_user password=12345678
+-- Test 12: GRANT non-babelfish role TO CURRENT_ROLE (babelfish role) should be blocked
+GRANT babel_6839_test_role TO CURRENT_ROLE;
+GO
+
+-- psql user=babel_6839_bbf_user password=12345678
+-- Test 13: GRANT non-babelfish role TO SESSION_USER (babelfish role) should be blocked
+GRANT babel_6839_test_role TO SESSION_USER;
+GO
+
+-- terminate-psql-conn user=babel_6839_bbf_user password=12345678
+
+-- tsql
+-- Cleanup babelfish login
+DROP LOGIN babel_6839_bbf_user;
+GO
+
 -- Cleanup
+-- psql
 DROP USER babel_6839_pg_user;
 GO
 


### PR DESCRIPTION
### Description

Fix NULL pointer dereference in is_babelfish_role() for GRANT/REVOKE with CURRENT_USER
  
 handle_grant_role() passed rolespec->rolename directly to is_babelfish_role() without checking rolespec->roletype. For CURRENT_USER, CURRENT_ROLE, and SESSION_USER, rolename is NULL (only ROLESPEC_CSTRING populates it), causing a segfault in get_role_oid() -> strlen(NULL).
  
Fix: resolve the actual role name from the OID via GetUserNameFromId() instead of using rolespec->rolename directly. Also add a NULL guard in is_babelfish_role() for defense-in-depth.

### Issues Resolved

BABEL-6839

### Test Scenarios Covered ###
* **Use case based -** yes


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -** yes


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).