### PR TITLE
Add testing for allowed PG-endpoint operations on Babelfish objects

### DIFF
--- a/test/JDBC/expected/pg_operations_on_bbf_objects.out
+++ b/test/JDBC/expected/pg_operations_on_bbf_objects.out
@@ -18,7 +18,7 @@ CREATE TABLE metadata_from_pg_child (a int REFERENCES metadata_from_pg_parent(a)
 GO
 CREATE TABLE metadata_from_pg_trg_tab (a int);
 GO
-CREATE TABLE trigger_counter (tally char(1));
+CREATE TABLE trigger_counter (tally char(10));
 GO
 CREATE TRIGGER metadata_from_pg_trg ON metadata_from_pg_trg_tab AFTER INSERT AS BEGIN INSERT INTO trigger_counter VALUES ('卌') END;
 GO

--- a/test/JDBC/expected/pg_operations_on_bbf_objects.out
+++ b/test/JDBC/expected/pg_operations_on_bbf_objects.out
@@ -105,7 +105,7 @@ f
 
 -- tsql
 INSERT INTO metadata_from_pg_dml VALUES (42, 42);
-SELECT * from metadata_from_pg_dml;
+SELECT * from metadata_from_pg_dml ORDER BY a;
 UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
 DELETE FROM metadata_from_pg_dml WHERE a = 42;
 GO
@@ -204,7 +204,7 @@ f
 
 -- tsql
 INSERT INTO metadata_from_pg_dml VALUES (42, 42);
-SELECT * from metadata_from_pg_dml;
+SELECT * from metadata_from_pg_dml ORDER BY a;
 UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
 DELETE FROM metadata_from_pg_dml WHERE a = 42;
 GO
@@ -279,7 +279,7 @@ GO
 
 ~~ERROR (Message: new row for relation "metadata_from_pg_struct" violates check constraint "metadata_from_pg_struct_chk")~~
 
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 UPDATE metadata_from_pg_struct SET b = NULL WHERE a = 42;
 DELETE FROM metadata_from_pg_struct WHERE a = 42;
 GO
@@ -325,7 +325,7 @@ f
 INSERT INTO metadata_from_pg_struct VALUES (42, 42);
 INSERT INTO metadata_from_pg_struct VALUES (-1, 42);
 INSERT INTO metadata_from_pg_struct VALUES (NULL, 42);
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
 DELETE FROM metadata_from_pg_struct WHERE a = 42;
 GO
@@ -337,9 +337,9 @@ GO
 
 ~~START~~
 int#!#bigint
-42#!#42
--1#!#42
 <NULL>#!#42
+-1#!#42
+42#!#42
 ~~END~~
 
 ~~ROW COUNT: 1~~
@@ -363,14 +363,14 @@ f
 
 -- tsql
 INSERT INTO metadata_from_pg_struct VALUES (42, 42);
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 GO
 ~~ROW COUNT: 1~~
 
 ~~START~~
 int#!#bigint
--1#!#42
 <NULL>#!#42
+-1#!#42
 42#!#42
 ~~END~~
 
@@ -400,18 +400,18 @@ f
 
 
 -- tsql
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 GO
 ~~ERROR (Code: 33557097)~~
 
 ~~ERROR (Message: relation "metadata_from_pg_struct" does not exist)~~
 
-SELECT * from metadata_from_pg_struct_new;
+SELECT * FROM metadata_from_pg_struct_new ORDER BY a;
 GO
 ~~START~~
 int#!#bigint
--1#!#42
 <NULL>#!#42
+-1#!#42
 ~~END~~
 
 -- psql
@@ -430,12 +430,12 @@ f
 
 
 -- tsql
-SELECT * FROM metadata_from_pg_struct_new;
+SELECT * FROM metadata_from_pg_struct_new ORDER BY a;
 GO
 ~~START~~
 int#!#bigint
--1#!#42
 <NULL>#!#42
+-1#!#42
 ~~END~~
 
 -- psql
@@ -450,12 +450,12 @@ f
 
 
 -- tsql
-SELECT * FROM metadata_from_pg_struct_new;
+SELECT * FROM metadata_from_pg_struct_new ORDER BY a;
 GO
 ~~START~~
 int#!#bigint
--1#!#42
 <NULL>#!#42
+-1#!#42
 ~~END~~
 
 -- psql

--- a/test/JDBC/expected/pg_operations_on_bbf_objects.out
+++ b/test/JDBC/expected/pg_operations_on_bbf_objects.out
@@ -1,0 +1,752 @@
+-- tsql
+-- PG operations on T-SQL objects
+-- NOTE: CREATE TRIGGER/VIEW/PROCEDURE/FUNCTION must each be the only
+-- statement in their batch, so every statement gets its own GO.
+CREATE LOGIN metadata_from_pg_login WITH PASSWORD = '12345678';
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER metadata_from_pg_login;
+GO
+CREATE TABLE metadata_from_pg_dml (a int, b int);
+GO
+CREATE TABLE metadata_from_pg_struct (a int, b int);
+GO
+CREATE TABLE metadata_from_pg_grant (a int);
+GO
+CREATE TABLE metadata_from_pg_parent (a int PRIMARY KEY);
+GO
+CREATE TABLE metadata_from_pg_child (a int REFERENCES metadata_from_pg_parent(a));
+GO
+CREATE TABLE metadata_from_pg_trg_tab (a int);
+GO
+CREATE TABLE trigger_counter (tally char(1));
+GO
+CREATE TRIGGER metadata_from_pg_trg ON metadata_from_pg_trg_tab AFTER INSERT AS BEGIN INSERT INTO trigger_counter VALUES ('卌') END;
+GO
+CREATE VIEW metadata_from_pg_view AS SELECT 1 AS c;
+GO
+CREATE PROCEDURE metadata_from_pg_proc AS SELECT 1;
+GO
+CREATE FUNCTION metadata_from_pg_func() RETURNS INT BEGIN RETURN 1; END
+GO
+CREATE SEQUENCE metadata_from_pg_seq AS int START WITH 1;
+GO
+
+
+-- psql user=metadata_from_pg_login password=12345678
+-- the catalog should be consistent before any operation
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+
+--
+-- DML
+--
+INSERT INTO master_dbo.metadata_from_pg_dml VALUES (1, 10), (2, 20);
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~ROW COUNT: 2~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+SELECT a, b FROM master_dbo.metadata_from_pg_dml ORDER BY a;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+int4#!#int4
+1#!#10
+2#!#20
+~~END~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+UPDATE master_dbo.metadata_from_pg_dml SET b = 99 WHERE a = 1;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+DELETE FROM master_dbo.metadata_from_pg_dml WHERE a = 2;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+TRUNCATE master_dbo.metadata_from_pg_dml;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+INSERT INTO metadata_from_pg_dml VALUES (42, 42);
+SELECT * from metadata_from_pg_dml;
+UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
+DELETE FROM metadata_from_pg_dml WHERE a = 42;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+42#!#42
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+
+CREATE TRIGGER metadata_from_pg_dml_trigger ON metadata_from_pg_dml AFTER INSERT AS BEGIN INSERT INTO trigger_counter VALUES ('卌') END;
+GO
+
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+0
+~~END~~
+
+-- psql
+
+
+--
+-- the trigger should block further DML
+--
+INSERT INTO master_dbo.metadata_from_pg_dml VALUES (1, 10), (2, 20);
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: T-SQL trigger can not be executed from PostgreSQL function, procedure or trigger.
+    Server SQLState: 0A000)~~
+
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+0
+~~END~~
+
+-- psql
+
+SELECT a, b FROM master_dbo.metadata_from_pg_dml ORDER BY a;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+int4#!#int4
+~~END~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+UPDATE master_dbo.metadata_from_pg_dml SET b = 99 WHERE a = 1;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+DELETE FROM master_dbo.metadata_from_pg_dml WHERE a = 2;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+TRUNCATE master_dbo.metadata_from_pg_dml;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+INSERT INTO metadata_from_pg_dml VALUES (42, 42);
+SELECT * from metadata_from_pg_dml;
+UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
+DELETE FROM metadata_from_pg_dml WHERE a = 42;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#int
+42#!#42
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- psql
+
+--
+-- ALTER TABLE structure
+--
+ALTER TABLE master_dbo.metadata_from_pg_struct ADD COLUMN c int;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ALTER COLUMN b TYPE bigint;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ADD CONSTRAINT metadata_from_pg_struct_chk CHECK (a > 0);
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ALTER COLUMN a SET NOT NULL;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+INSERT INTO metadata_from_pg_struct VALUES (42, 42, NULL);
+GO
+~~ROW COUNT: 1~~
+
+INSERT INTO metadata_from_pg_struct VALUES (NULL, 42, NULL);
+GO
+~~ERROR (Code: 515)~~
+
+~~ERROR (Message: null value in column "a" of relation "metadata_from_pg_struct" violates not-null constraint)~~
+
+INSERT INTO metadata_from_pg_struct VALUES (-1, 42, NULL);
+GO
+~~ERROR (Code: 547)~~
+
+~~ERROR (Message: new row for relation "metadata_from_pg_struct" violates check constraint "metadata_from_pg_struct_chk")~~
+
+SELECT * from metadata_from_pg_struct;
+UPDATE metadata_from_pg_struct SET b = NULL WHERE a = 42;
+DELETE FROM metadata_from_pg_struct WHERE a = 42;
+GO
+~~START~~
+int#!#bigint#!#int
+42#!#42#!#<NULL>
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- psql
+
+ALTER TABLE master_dbo.metadata_from_pg_struct DROP COLUMN c;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+ALTER TABLE master_dbo.metadata_from_pg_struct DROP CONSTRAINT metadata_from_pg_struct_chk;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ALTER COLUMN a DROP NOT NULL;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+INSERT INTO metadata_from_pg_struct VALUES (42, 42);
+INSERT INTO metadata_from_pg_struct VALUES (-1, 42);
+INSERT INTO metadata_from_pg_struct VALUES (NULL, 42);
+SELECT * from metadata_from_pg_struct;
+UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
+DELETE FROM metadata_from_pg_struct WHERE a = 42;
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#bigint
+42#!#42
+-1#!#42
+<NULL>#!#42
+~~END~~
+
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- psql
+
+
+--
+-- RENAME COLUMN / RENAME TABLE
+--
+ALTER TABLE master_dbo.metadata_from_pg_struct RENAME COLUMN b TO b_renamed;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+INSERT INTO metadata_from_pg_struct VALUES (42, 42);
+SELECT * from metadata_from_pg_struct;
+GO
+~~ROW COUNT: 1~~
+
+~~START~~
+int#!#bigint
+-1#!#42
+<NULL>#!#42
+42#!#42
+~~END~~
+
+UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: column "b" of relation "metadata_from_pg_struct" does not exist)~~
+
+UPDATE metadata_from_pg_struct SET b_renamed = 0 WHERE a = 42;
+GO
+~~ROW COUNT: 1~~
+
+DELETE FROM metadata_from_pg_struct WHERE a = 42;
+GO
+~~ROW COUNT: 1~~
+
+-- psql
+
+ALTER TABLE master_dbo.metadata_from_pg_struct RENAME TO metadata_from_pg_struct_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT * from metadata_from_pg_struct;
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_struct" does not exist)~~
+
+SELECT * from metadata_from_pg_struct_new;
+GO
+~~START~~
+int#!#bigint
+-1#!#42
+<NULL>#!#42
+~~END~~
+
+-- psql
+
+
+--
+-- CREATE / DROP INDEX
+--
+CREATE INDEX metadata_from_pg_idx ON master_dbo.metadata_from_pg_struct_new (a);
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT * FROM metadata_from_pg_struct_new;
+GO
+~~START~~
+int#!#bigint
+-1#!#42
+<NULL>#!#42
+~~END~~
+
+-- psql
+
+DROP INDEX master_dbo.metadata_from_pg_idx;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT * FROM metadata_from_pg_struct_new;
+GO
+~~START~~
+int#!#bigint
+-1#!#42
+<NULL>#!#42
+~~END~~
+
+-- psql
+
+
+--
+-- RENAME / DROP SEQUENCE
+--
+ALTER SEQUENCE master_dbo.metadata_from_pg_seq RENAME TO metadata_from_pg_seq_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT currval('metadata_from_pg_seq');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_seq" does not exist)~~
+
+SELECT nextval('metadata_from_pg_seq');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_seq" does not exist)~~
+
+SELECT currval('metadata_from_pg_seq_new');
+GO
+~~START~~
+bigint
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: currval of sequence "metadata_from_pg_seq_new" is not yet defined in this session)~~
+
+SELECT nextval('metadata_from_pg_seq_new');
+GO
+~~START~~
+bigint
+1
+~~END~~
+
+-- psql
+
+DROP SEQUENCE master_dbo.metadata_from_pg_seq_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT currval('metadata_from_pg_seq');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_seq" does not exist)~~
+
+SELECT nextval('metadata_from_pg_seq');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_seq" does not exist)~~
+
+SELECT currval('metadata_from_pg_seq_new');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_seq_new" does not exist)~~
+
+SELECT nextval('metadata_from_pg_seq_new');
+GO
+~~ERROR (Code: 33557097)~~
+
+~~ERROR (Message: relation "metadata_from_pg_seq_new" does not exist)~~
+
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+1
+~~END~~
+
+-- psql
+
+
+--
+-- RENAME / DROP TRIGGER
+--
+ALTER TRIGGER metadata_from_pg_trg ON master_dbo.metadata_from_pg_trg_tab RENAME TO metadata_from_pg_trg_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+1
+~~END~~
+
+INSERT INTO metadata_from_pg_trg_tab VALUES (1);
+GO
+~~ROW COUNT: 1~~
+
+~~ROW COUNT: 1~~
+
+-- psql
+INSERT INTO master_dbo.metadata_from_pg_trg_tab VALUES (1);
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: T-SQL trigger can not be executed from PostgreSQL function, procedure or trigger.
+    Server SQLState: 0A000)~~
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+2
+~~END~~
+
+-- psql
+
+
+--
+-- CASCADE required: Babelfish creates a helper pg_proc for each T-SQL trigger
+--
+DROP TRIGGER metadata_from_pg_trg_new ON master_dbo.metadata_from_pg_trg_tab CASCADE;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: drop cascades to function master_dbo.metadata_from_pg_trg()  Server SQLState: 00000)~~
+
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: drop cascades to function master_dbo.metadata_from_pg_trg()  Server SQLState: 00000)~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+2
+~~END~~
+
+INSERT INTO metadata_from_pg_trg_tab VALUES (1);
+GO
+~~ROW COUNT: 1~~
+
+SELECT count(*) FROM trigger_counter;
+GO
+~~START~~
+int
+2
+~~END~~
+
+-- psql
+
+
+--
+-- GRANT / REVOKE object privileges
+--
+GRANT SELECT ON master_dbo.metadata_from_pg_grant TO master_guest;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+-- tsql
+SELECT * FROM metadata_from_pg_grant;
+GO
+~~START~~
+int
+~~END~~
+
+-- psql
+
+REVOKE SELECT ON master_dbo.metadata_from_pg_grant FROM master_guest;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+
+--
+-- DROP object types
+--
+DROP VIEW master_dbo.metadata_from_pg_view;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+DROP FUNCTION master_dbo.metadata_from_pg_func();
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+DROP PROCEDURE master_dbo.metadata_from_pg_proc();
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+DROP TABLE master_dbo.metadata_from_pg_grant;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+DROP TABLE master_dbo.metadata_from_pg_parent CASCADE;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: drop cascades to constraint metadata_from_pg_child_a_fkey on table master_dbo.metadata_from_pg_child  Server SQLState: 00000)~~
+
+~~WARNING (Code: 0)~~
+
+~~WARNING (Message: drop cascades to constraint metadata_from_pg_child_a_fkey on table master_dbo.metadata_from_pg_child  Server SQLState: 00000)~~
+
+~~START~~
+bool
+f
+~~END~~
+
+
+
+--
+-- Maintenance
+--
+ANALYZE master_dbo.metadata_from_pg_dml;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+~~START~~
+bool
+f
+~~END~~
+
+
+
+-- terminate-psql-conn user=metadata_from_pg_login password=12345678
+-- tsql
+-- cleanup
+DROP TABLE trigger_counter;
+GO
+DROP TABLE metadata_from_pg_dml;
+GO
+DROP TABLE metadata_from_pg_struct_new;
+GO
+DROP TABLE metadata_from_pg_child;
+GO
+DROP TABLE metadata_from_pg_trg_tab;
+GO
+DROP LOGIN metadata_from_pg_login;
+GO

--- a/test/JDBC/input/pg_operations_on_bbf_objects.mix
+++ b/test/JDBC/input/pg_operations_on_bbf_objects.mix
@@ -18,7 +18,7 @@ CREATE TABLE metadata_from_pg_child (a int REFERENCES metadata_from_pg_parent(a)
 GO
 CREATE TABLE metadata_from_pg_trg_tab (a int);
 GO
-CREATE TABLE trigger_counter (tally char(1));
+CREATE TABLE trigger_counter (tally char(10));
 GO
 CREATE TRIGGER metadata_from_pg_trg ON metadata_from_pg_trg_tab AFTER INSERT AS BEGIN INSERT INTO trigger_counter VALUES ('卌') END;
 GO

--- a/test/JDBC/input/pg_operations_on_bbf_objects.mix
+++ b/test/JDBC/input/pg_operations_on_bbf_objects.mix
@@ -1,0 +1,361 @@
+-- tsql
+-- PG operations on T-SQL objects
+-- NOTE: CREATE TRIGGER/VIEW/PROCEDURE/FUNCTION must each be the only
+-- statement in their batch, so every statement gets its own GO.
+CREATE LOGIN metadata_from_pg_login WITH PASSWORD = '12345678';
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER metadata_from_pg_login;
+GO
+CREATE TABLE metadata_from_pg_dml (a int, b int);
+GO
+CREATE TABLE metadata_from_pg_struct (a int, b int);
+GO
+CREATE TABLE metadata_from_pg_grant (a int);
+GO
+CREATE TABLE metadata_from_pg_parent (a int PRIMARY KEY);
+GO
+CREATE TABLE metadata_from_pg_child (a int REFERENCES metadata_from_pg_parent(a));
+GO
+CREATE TABLE metadata_from_pg_trg_tab (a int);
+GO
+CREATE TABLE trigger_counter (tally char(1));
+GO
+CREATE TRIGGER metadata_from_pg_trg ON metadata_from_pg_trg_tab AFTER INSERT AS BEGIN INSERT INTO trigger_counter VALUES ('卌') END;
+GO
+CREATE VIEW metadata_from_pg_view AS SELECT 1 AS c;
+GO
+CREATE PROCEDURE metadata_from_pg_proc AS SELECT 1;
+GO
+CREATE FUNCTION metadata_from_pg_func() RETURNS INT BEGIN RETURN 1; END
+GO
+CREATE SEQUENCE metadata_from_pg_seq AS int START WITH 1;
+GO
+
+
+-- psql user=metadata_from_pg_login password=12345678
+-- the catalog should be consistent before any operation
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+
+--
+-- DML
+--
+INSERT INTO master_dbo.metadata_from_pg_dml VALUES (1, 10), (2, 20);
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+SELECT a, b FROM master_dbo.metadata_from_pg_dml ORDER BY a;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+UPDATE master_dbo.metadata_from_pg_dml SET b = 99 WHERE a = 1;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+DELETE FROM master_dbo.metadata_from_pg_dml WHERE a = 2;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+TRUNCATE master_dbo.metadata_from_pg_dml;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+INSERT INTO metadata_from_pg_dml VALUES (42, 42);
+SELECT * from metadata_from_pg_dml;
+UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
+DELETE FROM metadata_from_pg_dml WHERE a = 42;
+GO
+
+CREATE TRIGGER metadata_from_pg_dml_trigger ON metadata_from_pg_dml AFTER INSERT AS BEGIN INSERT INTO trigger_counter VALUES ('卌') END;
+GO
+
+SELECT count(*) FROM trigger_counter;
+GO
+-- psql
+
+
+--
+-- the trigger should block further DML
+--
+INSERT INTO master_dbo.metadata_from_pg_dml VALUES (1, 10), (2, 20);
+GO
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+-- psql
+
+SELECT a, b FROM master_dbo.metadata_from_pg_dml ORDER BY a;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+UPDATE master_dbo.metadata_from_pg_dml SET b = 99 WHERE a = 1;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+DELETE FROM master_dbo.metadata_from_pg_dml WHERE a = 2;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+TRUNCATE master_dbo.metadata_from_pg_dml;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+INSERT INTO metadata_from_pg_dml VALUES (42, 42);
+SELECT * from metadata_from_pg_dml;
+UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
+DELETE FROM metadata_from_pg_dml WHERE a = 42;
+GO
+-- psql
+
+--
+-- ALTER TABLE structure
+--
+ALTER TABLE master_dbo.metadata_from_pg_struct ADD COLUMN c int;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ALTER COLUMN b TYPE bigint;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ADD CONSTRAINT metadata_from_pg_struct_chk CHECK (a > 0);
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ALTER COLUMN a SET NOT NULL;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+INSERT INTO metadata_from_pg_struct VALUES (42, 42, NULL);
+GO
+INSERT INTO metadata_from_pg_struct VALUES (NULL, 42, NULL);
+GO
+INSERT INTO metadata_from_pg_struct VALUES (-1, 42, NULL);
+GO
+SELECT * from metadata_from_pg_struct;
+UPDATE metadata_from_pg_struct SET b = NULL WHERE a = 42;
+DELETE FROM metadata_from_pg_struct WHERE a = 42;
+GO
+-- psql
+
+ALTER TABLE master_dbo.metadata_from_pg_struct DROP COLUMN c;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+ALTER TABLE master_dbo.metadata_from_pg_struct DROP CONSTRAINT metadata_from_pg_struct_chk;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+ALTER TABLE master_dbo.metadata_from_pg_struct ALTER COLUMN a DROP NOT NULL;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+INSERT INTO metadata_from_pg_struct VALUES (42, 42);
+INSERT INTO metadata_from_pg_struct VALUES (-1, 42);
+INSERT INTO metadata_from_pg_struct VALUES (NULL, 42);
+SELECT * from metadata_from_pg_struct;
+UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
+DELETE FROM metadata_from_pg_struct WHERE a = 42;
+GO
+-- psql
+
+
+--
+-- RENAME COLUMN / RENAME TABLE
+--
+ALTER TABLE master_dbo.metadata_from_pg_struct RENAME COLUMN b TO b_renamed;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+INSERT INTO metadata_from_pg_struct VALUES (42, 42);
+SELECT * from metadata_from_pg_struct;
+GO
+UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
+GO
+UPDATE metadata_from_pg_struct SET b_renamed = 0 WHERE a = 42;
+GO
+DELETE FROM metadata_from_pg_struct WHERE a = 42;
+GO
+-- psql
+
+ALTER TABLE master_dbo.metadata_from_pg_struct RENAME TO metadata_from_pg_struct_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT * from metadata_from_pg_struct;
+GO
+SELECT * from metadata_from_pg_struct_new;
+GO
+-- psql
+
+
+--
+-- CREATE / DROP INDEX
+--
+CREATE INDEX metadata_from_pg_idx ON master_dbo.metadata_from_pg_struct_new (a);
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT * FROM metadata_from_pg_struct_new;
+GO
+-- psql
+
+DROP INDEX master_dbo.metadata_from_pg_idx;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT * FROM metadata_from_pg_struct_new;
+GO
+-- psql
+
+
+--
+-- RENAME / DROP SEQUENCE
+--
+ALTER SEQUENCE master_dbo.metadata_from_pg_seq RENAME TO metadata_from_pg_seq_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT currval('metadata_from_pg_seq');
+GO
+SELECT nextval('metadata_from_pg_seq');
+GO
+SELECT currval('metadata_from_pg_seq_new');
+GO
+SELECT nextval('metadata_from_pg_seq_new');
+GO
+-- psql
+
+DROP SEQUENCE master_dbo.metadata_from_pg_seq_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT currval('metadata_from_pg_seq');
+GO
+SELECT nextval('metadata_from_pg_seq');
+GO
+SELECT currval('metadata_from_pg_seq_new');
+GO
+SELECT nextval('metadata_from_pg_seq_new');
+GO
+SELECT count(*) FROM trigger_counter;
+GO
+-- psql
+
+
+--
+-- RENAME / DROP TRIGGER
+--
+ALTER TRIGGER metadata_from_pg_trg ON master_dbo.metadata_from_pg_trg_tab RENAME TO metadata_from_pg_trg_new;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+INSERT INTO metadata_from_pg_trg_tab VALUES (1);
+GO
+-- psql
+INSERT INTO master_dbo.metadata_from_pg_trg_tab VALUES (1);
+GO
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+-- psql
+
+
+--
+-- CASCADE required: Babelfish creates a helper pg_proc for each T-SQL trigger
+--
+DROP TRIGGER metadata_from_pg_trg_new ON master_dbo.metadata_from_pg_trg_tab CASCADE;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT count(*) FROM trigger_counter;
+GO
+INSERT INTO metadata_from_pg_trg_tab VALUES (1);
+GO
+SELECT count(*) FROM trigger_counter;
+GO
+-- psql
+
+
+--
+-- GRANT / REVOKE object privileges
+--
+GRANT SELECT ON master_dbo.metadata_from_pg_grant TO master_guest;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+-- tsql
+SELECT * FROM metadata_from_pg_grant;
+GO
+-- psql
+
+REVOKE SELECT ON master_dbo.metadata_from_pg_grant FROM master_guest;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+
+--
+-- DROP object types
+--
+DROP VIEW master_dbo.metadata_from_pg_view;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+DROP FUNCTION master_dbo.metadata_from_pg_func();
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+DROP PROCEDURE master_dbo.metadata_from_pg_proc();
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+DROP TABLE master_dbo.metadata_from_pg_grant;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+DROP TABLE master_dbo.metadata_from_pg_parent CASCADE;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+
+--
+-- Maintenance
+--
+ANALYZE master_dbo.metadata_from_pg_dml;
+SELECT sys.check_for_inconsistent_metadata();
+GO
+
+
+-- terminate-psql-conn user=metadata_from_pg_login password=12345678
+-- tsql
+-- cleanup
+DROP TABLE trigger_counter;
+GO
+DROP TABLE metadata_from_pg_dml;
+GO
+DROP TABLE metadata_from_pg_struct_new;
+GO
+DROP TABLE metadata_from_pg_child;
+GO
+DROP TABLE metadata_from_pg_trg_tab;
+GO
+DROP LOGIN metadata_from_pg_login;
+GO

--- a/test/JDBC/input/pg_operations_on_bbf_objects.mix
+++ b/test/JDBC/input/pg_operations_on_bbf_objects.mix
@@ -63,7 +63,7 @@ GO
 
 -- tsql
 INSERT INTO metadata_from_pg_dml VALUES (42, 42);
-SELECT * from metadata_from_pg_dml;
+SELECT * from metadata_from_pg_dml ORDER BY a;
 UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
 DELETE FROM metadata_from_pg_dml WHERE a = 42;
 GO
@@ -107,7 +107,7 @@ GO
 
 -- tsql
 INSERT INTO metadata_from_pg_dml VALUES (42, 42);
-SELECT * from metadata_from_pg_dml;
+SELECT * from metadata_from_pg_dml ORDER BY a;
 UPDATE metadata_from_pg_dml SET b = 0 WHERE a = 42;
 DELETE FROM metadata_from_pg_dml WHERE a = 42;
 GO
@@ -139,7 +139,7 @@ INSERT INTO metadata_from_pg_struct VALUES (NULL, 42, NULL);
 GO
 INSERT INTO metadata_from_pg_struct VALUES (-1, 42, NULL);
 GO
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 UPDATE metadata_from_pg_struct SET b = NULL WHERE a = 42;
 DELETE FROM metadata_from_pg_struct WHERE a = 42;
 GO
@@ -161,7 +161,7 @@ GO
 INSERT INTO metadata_from_pg_struct VALUES (42, 42);
 INSERT INTO metadata_from_pg_struct VALUES (-1, 42);
 INSERT INTO metadata_from_pg_struct VALUES (NULL, 42);
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
 DELETE FROM metadata_from_pg_struct WHERE a = 42;
 GO
@@ -177,7 +177,7 @@ GO
 
 -- tsql
 INSERT INTO metadata_from_pg_struct VALUES (42, 42);
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 GO
 UPDATE metadata_from_pg_struct SET b = 0 WHERE a = 42;
 GO
@@ -192,9 +192,9 @@ SELECT sys.check_for_inconsistent_metadata();
 GO
 
 -- tsql
-SELECT * from metadata_from_pg_struct;
+SELECT * FROM metadata_from_pg_struct ORDER BY a;
 GO
-SELECT * from metadata_from_pg_struct_new;
+SELECT * FROM metadata_from_pg_struct_new ORDER BY a;
 GO
 -- psql
 
@@ -207,7 +207,7 @@ SELECT sys.check_for_inconsistent_metadata();
 GO
 
 -- tsql
-SELECT * FROM metadata_from_pg_struct_new;
+SELECT * FROM metadata_from_pg_struct_new ORDER BY a;
 GO
 -- psql
 
@@ -216,7 +216,7 @@ SELECT sys.check_for_inconsistent_metadata();
 GO
 
 -- tsql
-SELECT * FROM metadata_from_pg_struct_new;
+SELECT * FROM metadata_from_pg_struct_new ORDER BY a;
 GO
 -- psql
 


### PR DESCRIPTION
### Description

This commit adds tests to verify that operations from the PG endpoint on Babelfish objects do not lead to inconsistent metadata and the objects function correctly afterwards.


### Issues Resolved
Task: BABEL-7038


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).