### PR TITLE
Remove redundant FUNC → bbf_function_ext_idx ordering hint (#4954)

### DIFF
--- a/contrib/babelfishpg_tsql/src/hooks.c
+++ b/contrib/babelfishpg_tsql/src/hooks.c
@@ -4468,21 +4468,10 @@ pltsql_store_func_default_positions(ObjectAddress address, List *parameters, con
 	}
 	else
 	{
-		ObjectAddress index;
-
 		tuple = heap_form_tuple(bbf_function_ext_rel_dsc,
 								new_record, new_record_nulls);
 
 		CatalogTupleInsert(bbf_function_ext_rel, tuple);
-
-		/*
-		 * Add function's dependency on catalog table's index so that table
-		 * gets restored before function during MVU.
-		 */
-		index.classId = IndexRelationId;
-		index.objectId = get_bbf_function_ext_idx_oid();
-		index.objectSubId = 0;
-		recordDependencyOn(&address, &index, DEPENDENCY_NORMAL);
 	}
 
 	pfree(func_signature);


### PR DESCRIPTION
### Description

pltsql_store_func_default_positions() recorded a pg_depend row from every PL/tsql function to bbf_function_ext_pkey to hint pg_dump's restore ordering. This hint was never actually needed:

  * On the target, babelfishpg_tsql is installed BEFORE pg_restore runs, so bbf_function_ext already exists.
  * In binary_upgrade mode, pg_dump emits CREATE EXTENSION which creates bbf_function_ext before any user function, and pg_dump's extension-membership graph already orders things correctly.
  * The function's implicit dependency on the babelfishpg_tsql extension (via sys.* types / sys namespace) already provides the required ordering.

Worse, the edge now crosses the pre-data → post-data section boundary (INDEX is post-data, FUNC is pre-data). pg_dump breaks the resulting cycle by marking generated-column attrdefs as "separate", producing an invalid ALTER TABLE ... SET DEFAULT (col_ref) that pg_restore rejects with:

    ERROR:  cannot use column reference in DEFAULT expression

Remove the recordDependencyOn call entirely.

Author: Ayush Shah <ayushdsh@amazon.com>
(cherry picked from commit 1a2055e7fafbe4e15dc87bc8f45e03ee4b4c630a)



### Issues Resolved

BABEL-7014

### Test Scenarios Covered ###
No additional tests required. Fixes a redundant dependency.





### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).