### PR TITLE
[BABEL] Fix INSERT EXEC COMMIT failure when IMPLICIT_TRANSACTIONS is ON

### DIFF
--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -942,10 +942,6 @@ insert_exec_flush_and_cleanup(PLtsql_execstate *estate, InsertExecInfo *info)
 		estate->tsql_trigger_flags &= ~TSQL_TRAN_STARTED;
 
 		if (!pltsql_implicit_transactions)
-		{
-			elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
 			commit_stmt(estate, true);
-		}
-		elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
 	}
 }

--- a/contrib/babelfishpg_tsql/src/pl_insert_exec.c
+++ b/contrib/babelfishpg_tsql/src/pl_insert_exec.c
@@ -939,8 +939,13 @@ insert_exec_flush_and_cleanup(PLtsql_execstate *estate, InsertExecInfo *info)
 	 */
 	if (estate->tsql_trigger_flags & TSQL_TRAN_STARTED)
 	{
-		elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
-		commit_stmt(estate, true);
 		estate->tsql_trigger_flags &= ~TSQL_TRAN_STARTED;
+
+		if (!pltsql_implicit_transactions)
+		{
+			elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
+			commit_stmt(estate, true);
+		}
+		elog(DEBUG4, "TSQL TXN Commit implicit transaction for INSERT EXEC");
 	}
 }

--- a/test/JDBC/expected/BABEL-INSERT-EXEC.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXEC.out
@@ -1695,6 +1695,50 @@ DROP TABLE dbo.ie_rowcount;
 GO
 
 -- ============================================================================
+-- Category VI: INSERT EXEC with SET IMPLICIT_TRANSACTIONS ON
+-- ============================================================================
+CREATE TABLE dbo.ie_implicit_txn (val INT);
+GO
+CREATE PROCEDURE dbo.ie_implicit_txn_src AS
+    SELECT 10 UNION ALL SELECT 20;
+GO
+-- Test 1: COMMIT should succeed after INSERT EXEC
+SET IMPLICIT_TRANSACTIONS ON;
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src;
+COMMIT;
+SET IMPLICIT_TRANSACTIONS OFF;
+GO
+~~ROW COUNT: 2~~
+
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val; -- Expected: 10, 20
+GO
+~~START~~
+int
+10
+20
+~~END~~
+
+-- Test 2: ROLLBACK should undo the INSERT EXEC
+SET IMPLICIT_TRANSACTIONS ON;
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src;
+ROLLBACK;
+SET IMPLICIT_TRANSACTIONS OFF;
+GO
+~~ROW COUNT: 2~~
+
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val; -- Expected: 10, 20 (rollback undid second insert)
+GO
+~~START~~
+int
+10
+20
+~~END~~
+
+DROP PROCEDURE dbo.ie_implicit_txn_src;
+DROP TABLE dbo.ie_implicit_txn;
+GO
+
+-- ============================================================================
 -- Cleanup verification
 -- ============================================================================
 SELECT 'All INSERT EXEC tests completed successfully' AS status;

--- a/test/JDBC/expected/BABEL-INSERT-EXEC.out
+++ b/test/JDBC/expected/BABEL-INSERT-EXEC.out
@@ -1739,6 +1739,115 @@ DROP TABLE dbo.ie_implicit_txn;
 GO
 
 -- ============================================================================
+-- Category VII: INSERT EXEC with SET IMPLICIT_TRANSACTIONS ON
+-- ============================================================================
+CREATE TABLE dbo.ie_implicit_txn (val INT);
+GO
+CREATE PROCEDURE dbo.ie_implicit_txn_src AS
+    SELECT 10 UNION ALL SELECT 20;
+GO
+
+SET IMPLICIT_TRANSACTIONS ON
+GO
+
+-- INSERT EXEC should start implicit transaction and keep it open (core bug)
+SELECT @@TRANCOUNT
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+0
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+
+-- Data should persist after COMMIT
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val
+GO
+~~START~~
+int
+10
+20
+~~END~~
+
+
+-- INSERT EXEC followed by ROLLBACK should undo the rows
+SELECT @@TRANCOUNT
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src
+SELECT @@TRANCOUNT
+ROLLBACK
+SELECT @@TRANCOUNT
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+0
+~~END~~
+
+
+-- Verify rows were rolled back (only committed rows from first test remain)
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val
+GO
+~~START~~
+int
+10
+20
+~~END~~
+
+
+-- INSERT EXEC inside an explicit transaction should not prematurely commit
+SELECT @@TRANCOUNT
+BEGIN TRANSACTION
+SELECT @@TRANCOUNT
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+~~START~~
+int
+1
+~~END~~
+
+~~START~~
+int
+2
+~~END~~
+
+~~ROW COUNT: 2~~
+
+~~START~~
+int
+2
+~~END~~
+
+
+SET IMPLICIT_TRANSACTIONS OFF
+GO
+DROP PROCEDURE dbo.ie_implicit_txn_src;
+DROP TABLE dbo.ie_implicit_txn;
+GO
+
+-- ============================================================================
 -- Cleanup verification
 -- ============================================================================
 SELECT 'All INSERT EXEC tests completed successfully' AS status;

--- a/test/JDBC/input/BABEL-INSERT-EXEC.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXEC.sql
@@ -1229,6 +1229,34 @@ DROP TABLE dbo.ie_rowcount;
 GO
 
 -- ============================================================================
+-- Category VI: INSERT EXEC with SET IMPLICIT_TRANSACTIONS ON
+-- ============================================================================
+CREATE TABLE dbo.ie_implicit_txn (val INT);
+GO
+CREATE PROCEDURE dbo.ie_implicit_txn_src AS
+    SELECT 10 UNION ALL SELECT 20;
+GO
+-- Test 1: COMMIT should succeed after INSERT EXEC
+SET IMPLICIT_TRANSACTIONS ON;
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src;
+COMMIT;
+SET IMPLICIT_TRANSACTIONS OFF;
+GO
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val; -- Expected: 10, 20
+GO
+-- Test 2: ROLLBACK should undo the INSERT EXEC
+SET IMPLICIT_TRANSACTIONS ON;
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src;
+ROLLBACK;
+SET IMPLICIT_TRANSACTIONS OFF;
+GO
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val; -- Expected: 10, 20 (rollback undid second insert)
+GO
+DROP PROCEDURE dbo.ie_implicit_txn_src;
+DROP TABLE dbo.ie_implicit_txn;
+GO
+
+-- ============================================================================
 -- Cleanup verification
 -- ============================================================================
 SELECT 'All INSERT EXEC tests completed successfully' AS status;

--- a/test/JDBC/input/BABEL-INSERT-EXEC.sql
+++ b/test/JDBC/input/BABEL-INSERT-EXEC.sql
@@ -1257,6 +1257,57 @@ DROP TABLE dbo.ie_implicit_txn;
 GO
 
 -- ============================================================================
+-- Category VII: INSERT EXEC with SET IMPLICIT_TRANSACTIONS ON
+-- ============================================================================
+CREATE TABLE dbo.ie_implicit_txn (val INT);
+GO
+CREATE PROCEDURE dbo.ie_implicit_txn_src AS
+    SELECT 10 UNION ALL SELECT 20;
+GO
+
+SET IMPLICIT_TRANSACTIONS ON
+GO
+
+-- INSERT EXEC should start implicit transaction and keep it open (core bug)
+SELECT @@TRANCOUNT
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
+-- Data should persist after COMMIT
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val
+GO
+
+-- INSERT EXEC followed by ROLLBACK should undo the rows
+SELECT @@TRANCOUNT
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src
+SELECT @@TRANCOUNT
+ROLLBACK
+SELECT @@TRANCOUNT
+GO
+
+-- Verify rows were rolled back (only committed rows from first test remain)
+SELECT val FROM dbo.ie_implicit_txn ORDER BY val
+GO
+
+-- INSERT EXEC inside an explicit transaction should not prematurely commit
+SELECT @@TRANCOUNT
+BEGIN TRANSACTION
+SELECT @@TRANCOUNT
+INSERT INTO dbo.ie_implicit_txn EXEC dbo.ie_implicit_txn_src
+SELECT @@TRANCOUNT
+IF @@TRANCOUNT > 0 COMMIT
+IF @@TRANCOUNT > 0 COMMIT
+GO
+
+SET IMPLICIT_TRANSACTIONS OFF
+GO
+DROP PROCEDURE dbo.ie_implicit_txn_src;
+DROP TABLE dbo.ie_implicit_txn;
+GO
+
+-- ============================================================================
 -- Cleanup verification
 -- ============================================================================
 SELECT 'All INSERT EXEC tests completed successfully' AS status;


### PR DESCRIPTION
### Description


Currently, after `INSERT ... EXEC` completes, Babelfish unconditionally calls
`commit_stmt()` to close the implicit transaction that was opened for the
statement. When `IMPLICIT_TRANSACTIONS ON` is set, the session manages its own
open transaction — committing it mid-statement causes the transaction to close
prematurely, producing an error on any subsequent `COMMIT` or DML.

With this change, `commit_stmt()` is skipped when `pltsql_implicit_transactions`
is enabled. The implicit transaction opened by `insert_exec_setup()` is left
open, showing the expected behavior where the caller is responsible for
committing or rolling back the transaction.

### Issues Resolved

- BABEL-6888: INSERT EXEC with IMPLICIT_TRANSACTIONS ON fails on COMMIT

### Test Scenarios Covered ###
* **Use case based -**
  - `INSERT INTO t EXEC sp_test` with `SET IMPLICIT_TRANSACTIONS ON` — executes
    successfully; subsequent explicit `COMMIT` completes without error.

* **Boundary conditions -**
  - `SET IMPLICIT_TRANSACTIONS OFF` (default) — existing commit path unchanged;
    `if (!pltsql_implicit_transactions)` guard is true and `commit_stmt()` still runs.

* **Negative test cases -**
  - `INSERT EXEC` followed by `ROLLBACK` under `IMPLICIT_TRANSACTIONS ON` —
    rolls back cleanly with no orphaned transaction.

* **Minor version upgrade tests -** N/A
* **Major version upgrade tests -** N/A
* **Performance tests -** No impact; single boolean check added to existing branch.
* **Tooling impact -** None.
* **Client tests -** Tested via `sqlcmd` on localhost:1433.



### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).