### PR TITLE
Add GUC for blocking ALTER ... RENAME TO on BBF objects from the PG endpoint

### DIFF
--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -72,6 +72,7 @@ char	   *pltsql_host_service_pack_level = NULL;
 
 bool		pltsql_enable_create_alter_view_from_pg = false;
 bool		pltsql_enable_alter_owner_from_pg = false;
+bool		pltsql_enable_rename_from_pg = false;
 bool		pltsql_enable_antlr_parse_cache = false;
 bool		pltsql_validate_antlr_parse_cache = false;
 
@@ -1133,6 +1134,18 @@ define_custom_variables(void)
 							 gettext_noop("Enables blocked ALTER .. OWNER .. statements on TSQL objects from PG endpoint"),
 							 NULL,
 							 &pltsql_enable_alter_owner_from_pg,
+							 false,
+							 PGC_SUSET,
+							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,
+							 NULL, NULL, NULL);
+
+	/*
+	 * Block ALTER .. OWNER .. from PG endpoint executed on TSQL objects.
+	 */
+	DefineCustomBoolVariable("babelfishpg_tsql.enable_rename_from_pg",
+							 gettext_noop("Enables blocked ALTER .. RENAME TO .. statements on TSQL objects from PG endpoint"),
+							 NULL,
+							 &pltsql_enable_rename_from_pg,
 							 false,
 							 PGC_SUSET,
 							 GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE | GUC_DISALLOW_IN_AUTO_FILE,

--- a/contrib/babelfishpg_tsql/src/guc.c
+++ b/contrib/babelfishpg_tsql/src/guc.c
@@ -1140,11 +1140,13 @@ define_custom_variables(void)
 							 NULL, NULL, NULL);
 
 	/*
-	 * Block ALTER .. OWNER .. from PG endpoint executed on TSQL objects.
+	 * Block ALTER .. RENAME TO .., ALTER .. SET SCHEMA .., and CALL sys.sp_rename from the PG endpoint executed on TSQL objects.
 	 */
 	DefineCustomBoolVariable("babelfishpg_tsql.enable_rename_from_pg",
-							 gettext_noop("Enables blocked ALTER .. RENAME TO .. statements on TSQL objects from PG endpoint"),
-							 NULL,
+							 gettext_noop("Enables blocked ALTER statements on TSQL objects from PG endpoint"),
+							 gettext_noop("When enabled, ALTER .. RENAME TO .., ALTER .. SET SCHEMA .., "
+										  "and CALL sys.sp_rename statements are allowed on TSQL objects "
+										  "from the PG endpoint."),
 							 &pltsql_enable_rename_from_pg,
 							 false,
 							 PGC_SUSET,

--- a/contrib/babelfishpg_tsql/src/guc.h
+++ b/contrib/babelfishpg_tsql/src/guc.h
@@ -18,6 +18,7 @@ typedef enum IsolationOptions
 extern bool pltsql_fmtonly;
 extern bool pltsql_enable_create_alter_view_from_pg;
 extern bool	pltsql_enable_alter_owner_from_pg;
+extern bool	pltsql_enable_rename_from_pg;
 extern bool pltsql_enable_antlr_parse_cache;
 extern bool pltsql_validate_antlr_parse_cache;
 

--- a/contrib/babelfishpg_tsql/src/pl_handler.c
+++ b/contrib/babelfishpg_tsql/src/pl_handler.c
@@ -5225,7 +5225,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				/*
 				 * Block SET SCHEMA of TSQL functions/procedures from the PG endpoint.
 				 */
-				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !superuser())
+				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !pltsql_enable_rename_from_pg && !superuser())
 					restrict_alter_object_schema_stmt((AlterObjectSchemaStmt *) parsetree);
 
 				break;
@@ -5235,7 +5235,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				/*
 				 * Block CALL sys.sp_rename from the PG endpoint.
 				 */
-				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !superuser())
+				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !pltsql_enable_rename_from_pg && !superuser())
 					restrict_call_stmt((CallStmt *) parsetree);
 
 				break;
@@ -5248,7 +5248,7 @@ bbf_ProcessUtility(PlannedStmt *pstmt,
 				 * Block RENAME TSQL functions/procedures, and RENAME of the
 				 * sys and information_schema_tsql schemas from the PG endpoint.
 				 */
-				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !superuser())
+				if (sql_dialect == SQL_DIALECT_PG && !babelfish_dump_restore && !pltsql_enable_rename_from_pg && !superuser())
 					restrict_rename_stmt(stmt);
 
 				if (prev_ProcessUtility)

--- a/test/JDBC/expected/rename_restrictions_from_pg_guc.out
+++ b/test/JDBC/expected/rename_restrictions_from_pg_guc.out
@@ -1,0 +1,116 @@
+-- tsql
+CREATE LOGIN rename_from_pg_guc_u_neg WITH PASSWORD = '12345678';
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER rename_from_pg_guc_u_neg;
+GO
+CREATE LOGIN rename_from_pg_guc_u_pos WITH PASSWORD = '12345678';
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER rename_from_pg_guc_u_pos;
+GO
+
+CREATE PROCEDURE rename_from_pg_guc_p1 AS SELECT 1;
+GO
+CREATE PROCEDURE rename_from_pg_guc_p2 AS SELECT 1;
+GO
+CREATE PROCEDURE rename_from_pg_guc_p3 AS SELECT 1;
+GO
+
+-- psql
+GRANT CREATE ON SCHEMA public TO rename_from_pg_guc_u_neg;
+GO
+GRANT CREATE ON SCHEMA public TO rename_from_pg_guc_u_pos;
+GO
+
+-- psql user=rename_from_pg_guc_u_neg password=12345678
+-- negative cases: GUC off, all three operation types must be blocked
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1 RENAME TO rename_from_pg_guc_p1_new;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. RENAME .. is blocked in PG dialect on TSQL object "master_dbo.rename_from_pg_guc_p1".
+    Server SQLState: 0A000)~~
+
+
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p2 SET SCHEMA public;
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. SET SCHEMA .. is blocked in PG dialect on TSQL object "master_dbo.rename_from_pg_guc_p2" from schema "master_dbo".
+    Server SQLState: 0A000)~~
+
+
+SET psql_logical_babelfish_db_name = 'master';
+GO
+CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3', 'rename_from_pg_guc_p3_new', 'OBJECT');
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: sp_rename is blocked in PG dialect.
+    Server SQLState: 0A000)~~
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.enable_rename_from_pg = on;
+GO
+
+-- psql user=rename_from_pg_guc_u_pos password=12345678
+-- positive cases: GUC on, all three operation types must succeed
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1 RENAME TO rename_from_pg_guc_p1_new;
+GO
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1_new RENAME TO rename_from_pg_guc_p1;
+GO
+
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p2 SET SCHEMA public;
+GO
+ALTER PROCEDURE public.rename_from_pg_guc_p2 SET SCHEMA master_dbo;
+GO
+
+-- these will still fail, not because of our block, but because sp_rename
+-- currently can't resolve the schema from the PG endpoint 
+SET psql_logical_babelfish_db_name = 'master';
+GO
+CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3', 'rename_from_pg_guc_p3_new', 'OBJECT');
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: schema "dbo" does not exist
+  Where: SQL statement "EXEC sys.babelfish_sp_rename_internal @subname, @newname, @schemaname, @currtype, @curr_relname"
+PL/tsql function sp_rename(nvarchar,sysname,"varchar") line 131 at EXEC
+    Server SQLState: 3F000)~~
+
+CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3_new', 'rename_from_pg_guc_p3', 'OBJECT');
+GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: There is no object with the given @objname.
+  Where: PL/tsql function sp_rename(nvarchar,sysname,"varchar") line 108 at THROW
+    Server SQLState: YY001)~~
+
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- terminate-psql-conn user=rename_from_pg_guc_u_neg password=12345678
+-- terminate-psql-conn user=rename_from_pg_guc_u_pos password=12345678
+-- psql
+-- cleanup
+REVOKE CREATE ON SCHEMA public FROM rename_from_pg_guc_u_neg;
+GO
+REVOKE CREATE ON SCHEMA public FROM rename_from_pg_guc_u_pos;
+GO
+
+ALTER DATABASE babelfish_db RESET babelfishpg_tsql.enable_rename_from_pg;
+GO
+
+-- tsql
+DROP PROCEDURE rename_from_pg_guc_p1;
+GO
+DROP PROCEDURE rename_from_pg_guc_p2;
+GO
+DROP PROCEDURE rename_from_pg_guc_p3;
+GO
+DROP LOGIN rename_from_pg_guc_u_neg;
+GO
+DROP LOGIN rename_from_pg_guc_u_pos;
+GO

--- a/test/JDBC/expected/single_db/rename_restrictions_from_pg_guc.out
+++ b/test/JDBC/expected/single_db/rename_restrictions_from_pg_guc.out
@@ -1,4 +1,3 @@
--- single_db_mode_expected
 -- tsql
 CREATE LOGIN rename_from_pg_guc_u_neg WITH PASSWORD = '12345678';
 GO
@@ -22,18 +21,33 @@ GO
 GRANT CREATE ON SCHEMA public TO rename_from_pg_guc_u_pos;
 GO
 
--- negative cases: GUC off, all three operation types must be blocked
 -- psql user=rename_from_pg_guc_u_neg password=12345678
+-- negative cases: GUC off, all three operation types must be blocked
 ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1 RENAME TO rename_from_pg_guc_p1_new;
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. RENAME .. is blocked in PG dialect on TSQL object "master_dbo.rename_from_pg_guc_p1".
+    Server SQLState: 0A000)~~
+
 
 ALTER PROCEDURE master_dbo.rename_from_pg_guc_p2 SET SCHEMA public;
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: ALTER .. SET SCHEMA .. is blocked in PG dialect on TSQL object "master_dbo.rename_from_pg_guc_p2" from schema "master_dbo".
+    Server SQLState: 0A000)~~
+
 
 SET psql_logical_babelfish_db_name = 'master';
 GO
 CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3', 'rename_from_pg_guc_p3_new', 'OBJECT');
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: sp_rename is blocked in PG dialect.
+    Server SQLState: 0A000)~~
+
 RESET psql_logical_babelfish_db_name;
 GO
 
@@ -41,8 +55,8 @@ GO
 ALTER DATABASE babelfish_db SET babelfishpg_tsql.enable_rename_from_pg = on;
 GO
 
--- positive cases: GUC on, all three operation types must succeed
 -- psql user=rename_from_pg_guc_u_pos password=12345678
+-- positive cases: GUC on, all three operation types must succeed
 ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1 RENAME TO rename_from_pg_guc_p1_new;
 GO
 ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1_new RENAME TO rename_from_pg_guc_p1;
@@ -59,15 +73,28 @@ SET psql_logical_babelfish_db_name = 'master';
 GO
 CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3', 'rename_from_pg_guc_p3_new', 'OBJECT');
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: database "" does not exist. Make sure that the name is entered correctly.
+  Where: SQL statement "EXEC sys.babelfish_sp_rename_internal @subname, @newname, @schemaname, @currtype, @curr_relname"
+PL/tsql function sp_rename(nvarchar,sysname,"varchar") line 131 at EXEC
+    Server SQLState: 3D000)~~
+
 CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3_new', 'rename_from_pg_guc_p3', 'OBJECT');
 GO
+~~ERROR (Code: 0)~~
+
+~~ERROR (Message: ERROR: There is no object with the given @objname.
+  Where: PL/tsql function sp_rename(nvarchar,sysname,"varchar") line 108 at THROW
+    Server SQLState: YY001)~~
+
 RESET psql_logical_babelfish_db_name;
 GO
 
--- cleanup
 -- terminate-psql-conn user=rename_from_pg_guc_u_neg password=12345678
 -- terminate-psql-conn user=rename_from_pg_guc_u_pos password=12345678
 -- psql
+-- cleanup
 REVOKE CREATE ON SCHEMA public FROM rename_from_pg_guc_u_neg;
 GO
 REVOKE CREATE ON SCHEMA public FROM rename_from_pg_guc_u_pos;

--- a/test/JDBC/input/rename_restrictions_from_pg_guc.mix
+++ b/test/JDBC/input/rename_restrictions_from_pg_guc.mix
@@ -1,0 +1,88 @@
+-- tsql
+CREATE LOGIN rename_from_pg_guc_u_neg WITH PASSWORD = '12345678';
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER rename_from_pg_guc_u_neg;
+GO
+CREATE LOGIN rename_from_pg_guc_u_pos WITH PASSWORD = '12345678';
+GO
+ALTER SERVER ROLE sysadmin ADD MEMBER rename_from_pg_guc_u_pos;
+GO
+
+CREATE PROCEDURE rename_from_pg_guc_p1 AS SELECT 1;
+GO
+CREATE PROCEDURE rename_from_pg_guc_p2 AS SELECT 1;
+GO
+CREATE PROCEDURE rename_from_pg_guc_p3 AS SELECT 1;
+GO
+
+-- psql
+GRANT CREATE ON SCHEMA public TO rename_from_pg_guc_u_neg;
+GO
+GRANT CREATE ON SCHEMA public TO rename_from_pg_guc_u_pos;
+GO
+
+-- negative cases: GUC off, all three operation types must be blocked
+-- psql user=rename_from_pg_guc_u_neg password=12345678
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1 RENAME TO rename_from_pg_guc_p1_new;
+GO
+
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p2 SET SCHEMA public;
+GO
+
+SET psql_logical_babelfish_db_name = 'master';
+GO
+CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3', 'rename_from_pg_guc_p3_new', 'OBJECT');
+GO
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- psql
+ALTER DATABASE babelfish_db SET babelfishpg_tsql.enable_rename_from_pg = on;
+GO
+
+-- positive cases: GUC on, all three operation types must succeed
+-- psql user=rename_from_pg_guc_u_pos password=12345678
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1 RENAME TO rename_from_pg_guc_p1_new;
+GO
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p1_new RENAME TO rename_from_pg_guc_p1;
+GO
+
+ALTER PROCEDURE master_dbo.rename_from_pg_guc_p2 SET SCHEMA public;
+GO
+ALTER PROCEDURE public.rename_from_pg_guc_p2 SET SCHEMA master_dbo;
+GO
+
+-- these will still fail, not because of our block, but because sp_rename
+-- currently can't resolve the schema from the PG endpoint 
+SET psql_logical_babelfish_db_name = 'master';
+GO
+CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3', 'rename_from_pg_guc_p3_new', 'OBJECT');
+GO
+CALL sys.sp_rename('master.dbo.rename_from_pg_guc_p3_new', 'rename_from_pg_guc_p3', 'OBJECT');
+GO
+RESET psql_logical_babelfish_db_name;
+GO
+
+-- cleanup
+-- terminate-psql-conn user=rename_from_pg_guc_u_neg password=12345678
+-- terminate-psql-conn user=rename_from_pg_guc_u_pos password=12345678
+-- psql
+REVOKE CREATE ON SCHEMA public FROM rename_from_pg_guc_u_neg;
+GO
+REVOKE CREATE ON SCHEMA public FROM rename_from_pg_guc_u_pos;
+GO
+
+ALTER DATABASE babelfish_db RESET babelfishpg_tsql.enable_rename_from_pg;
+GO
+
+-- tsql
+DROP PROCEDURE rename_from_pg_guc_p1;
+GO
+DROP PROCEDURE rename_from_pg_guc_p2;
+GO
+DROP PROCEDURE rename_from_pg_guc_p3;
+GO
+DROP LOGIN rename_from_pg_guc_u_neg;
+GO
+DROP LOGIN rename_from_pg_guc_u_pos;
+GO

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,7 +8,8 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-all
+#all
+rename_restrictions_from_pg_guc
 
 # These tests are ignored since latest changes with UTF-16<->binary conversion
 # They show the previous behavior of the conversion functions

--- a/test/JDBC/jdbc_schedule
+++ b/test/JDBC/jdbc_schedule
@@ -8,8 +8,7 @@
 #    new line
 # 6. If you want the framework to not run certain files, use: ignore#!#<test name>
 
-#all
-rename_restrictions_from_pg_guc
+all
 
 # These tests are ignored since latest changes with UTF-16<->binary conversion
 # They show the previous behavior of the conversion functions


### PR DESCRIPTION
### Description

This commit adds a GUC to control blocking renames on Babelfish objects from the PG endpoint.

### Issues Resolved

BABEL-7108

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).